### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,6 @@ include::{include_path}/plugin_header.asciidoc[]
 
 The Kafka Integration Plugin provides integrated plugins for working with the https://kafka.apache.org/[Kafka] distributed streaming platform.
 
-This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+This plugin uses Kafka Client 2.3.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 :no_codec!:


### PR DESCRIPTION
The doc (https://www.elastic.co/guide/en/logstash/current/plugins-integrations-kafka.html) currently indicates v10.0.0 of Kafka integration plugin uses Kafka Client 2.1.0.

>This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official Kafka compatibility reference. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.

Our jar dependency definition (https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.0.0/lib/logstash-integration-kafka_jars.rb#L4) actually shows 2.3.0.  This updates the documentation to be consistent.

