### PR TITLE
[Doc] Add links to input and output docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,9 @@ include::{include_path}/plugin_header.asciidoc[]
 
 The Kafka Integration Plugin provides integrated plugins for working with the https://kafka.apache.org/[Kafka] distributed streaming platform.
 
+ - {logstash-ref}/plugins-inputs-kafka.html[Kafka Input Plugin]
+ - {logstash-ref}/plugins-outputs-kafka.html[Kafka Output Plugin]
+ 
 This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 :no_codec!:


### PR DESCRIPTION
Add links to kafka input and output docs to be consistent with other integrations