### PR TITLE
Test: avoid insist usage in spec 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 10.0.1
   - Fix links in changelog pointing to stand-alone plugin changelogs.
+  - Refactor: scope java_import to plugin class
 
 ## 10.0.0
   - Initial release of the Kafka Integration Plugin, which combines

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -3,8 +3,6 @@ require 'logstash/outputs/base'
 require 'java'
 require 'logstash-integration-kafka_jars.rb'
 
-java_import org.apache.kafka.clients.producer.ProducerRecord
-
 # Write events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on
 # the broker.
 #
@@ -49,6 +47,9 @@ java_import org.apache.kafka.clients.producer.ProducerRecord
 #
 # Kafka producer configuration: http://kafka.apache.org/documentation.html#newproducerconfigs
 class LogStash::Outputs::Kafka < LogStash::Outputs::Base
+
+  java_import org.apache.kafka.clients.producer.ProducerRecord
+
   declare_threadsafe!
 
   config_name 'kafka'

--- a/spec/unit/outputs/kafka_spec.rb
+++ b/spec/unit/outputs/kafka_spec.rb
@@ -16,9 +16,9 @@ describe "outputs/kafka" do
 
     it 'should populate kafka config with default values' do
       kafka = LogStash::Outputs::Kafka.new(simple_kafka_config)
-      insist {kafka.bootstrap_servers} == 'localhost:9092'
-      insist {kafka.topic_id} == 'test'
-      insist {kafka.key_serializer} == 'org.apache.kafka.common.serialization.StringSerializer'
+      expect(kafka.bootstrap_servers).to eql 'localhost:9092'
+      expect(kafka.topic_id).to eql 'test'
+      expect(kafka.key_serializer).to eql 'org.apache.kafka.common.serialization.StringSerializer'
     end
   end
 
@@ -55,7 +55,7 @@ describe "outputs/kafka" do
       expect { kafka.register }.to raise_error(LogStash::ConfigurationError, /ssl_truststore_location must be set when SSL is enabled/)
     end
   end
-  
+
   context "when KafkaProducer#send() raises an exception" do
     let(:failcount) { (rand * 10).to_i }
     let(:sendcount) { failcount + 1 }


### PR DESCRIPTION
... for devutils 2.0 compatibility

also scoped `java_import` to reduce potential name clashes