### PR TITLE
Build: relax jar-dependencies requirements

### DIFF
--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
       "integration_plugins" => "logstash-input-kafka,logstash-output-kafka"
   }
 
-  s.add_development_dependency 'jar-dependencies', '~> 0.3.12'
+  s.add_development_dependency 'jar-dependencies', '>= 0.3.12'
 
   s.platform = RUBY_PLATFORM
 


### PR DESCRIPTION
... to be able to release (run `rake` tasks)

Bundler is having issues (using bundle exec) with default gems :
`ruby -rbundler/setup -S rake vendor`

```
Gem::LoadError: You have already activated jar-dependencies 0.4.0, but
your Gemfile requires jar-dependencies 0.3.12. Prepending `bundle exec`
to your command may solve this.
```
