### PR TITLE
Test: replace old (poseidon) kafka client

### DIFF
--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'
-  s.add_development_dependency 'poseidon'
+  s.add_development_dependency 'ruby-kafka'
   s.add_development_dependency 'snappy'
 end

--- a/spec/integration/outputs/kafka_spec.rb
+++ b/spec/integration/outputs/kafka_spec.rb
@@ -172,9 +172,9 @@ describe "outputs/kafka", :integration => true do
       consumer1_records = consumer1.fetch
       consumer2_records = consumer2.fetch
 
-      expect(consumer0_records.size > 1 &&
-        consumer1_records.size > 1 &&
-          consumer2_records.size > 1).to be true
+      expect(consumer0_records.size).to be > 1
+      expect(consumer1_records.size).to be > 1
+      expect(consumer2_records.size).to be > 1
 
       all_records = consumer0_records + consumer1_records + consumer2_records
       expect(all_records.size).to eq(num_events)


### PR DESCRIPTION
[poseidon](https://github.com/bpot/poseidon) gem is defunct, **ruby-kafka** client just reached 1.0.0 so should be a decent alternative

The motivation here is to make sure nothing is interfering as we'll upgrade Kafka clients lib (to 2.4).
