### PR TITLE
[Doc]Reorder options for kafka input

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -81,6 +81,7 @@ NOTE: Some of these options map to a Kafka option. See the https://kafka.apache.
 | <<plugins-{type}s-{plugin}-bootstrap_servers>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-check_crcs>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-client_id>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-client_rack>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-connections_max_idle_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-consumer_threads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-decorate_events>> |<<boolean,boolean>>|No
@@ -121,7 +122,6 @@ NOTE: Some of these options map to a Kafka option. See the https://kafka.apache.
 | <<plugins-{type}s-{plugin}-topics>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-topics_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-value_deserializer_class>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-client_rack>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -181,6 +181,19 @@ disabled in cases seeking extreme performance.
 The id string to pass to the server when making requests. The purpose of this
 is to be able to track the source of requests beyond just ip/port by allowing
 a logical application name to be included.
+
+[id="plugins-{type}s-{plugin}-client_rack"]
+===== `client_rack` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+A rack identifier for the Kafka consumer. 
+Used to select the physically closest rack for the consumer to read from.
+The setting corresponds with Kafka's `broker.rack` configuration.
+
+NOTE: Available only for Kafka 2.4.0 and higher. See
+https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica[KIP-392].
 
 [id="plugins-{type}s-{plugin}-connections_max_idle_ms"]
 ===== `connections_max_idle_ms` 
@@ -582,19 +595,6 @@ The topics configuration will be ignored when using this configuration.
   * Default value is `"org.apache.kafka.common.serialization.StringDeserializer"`
 
 Java Class used to deserialize the record's value
-
-
-[id="plugins-{type}s-{plugin}-client_rack"]
-===== `client_rack` 
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-A rack identifier for the Kafka consumer. 
-Used to select the physically closest rack for the consumer to read from.
-The setting corresponds with Kafka's `broker.rack` configuration.
-
-NOTE: Only available for Kafka 2.4.0 and higher; see https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica[KIP-392].
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
Recently added options are at the end of the list. Moved to alphabetical order to be consistent with doc standards. 
