### PR TITLE
Fixed Kafka Client version in docs

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This input will read events from a Kafka topic.
 
-This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+This plugin uses Kafka Client 2.3.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need.
 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Write events to a Kafka topic. 
 
-This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+This plugin uses Kafka Client 2.3.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need.
 


### PR DESCRIPTION
The Kafka Client version is incorrectly stated as 2.1.0, but the [Kafka Integration](https://www.elastic.co/guide/en/logstash/7.7/plugins-integrations-kafka.html), [7.4 Release Notes](https://www.elastic.co/guide/en/logstash/current/logstash-7-4-0.html), and [7.4 Change Log](https://github.com/logstash-plugins/logstash-input-kafka/blob/v9.1.0/CHANGELOG.md) mention it has been upgraded to 2.3.0.

This PR fixes updates the docs to correctly reflect the current Kafka Client version.