### PR TITLE
Doc:Replace plugin_header file with plugin_header-integration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 10.5.1
-  - DOC:Replaced plugin_header file with plugin_header-integration file. [#46](https://github.com/logstash-plugins/logstash-integration-kafka/pull/46)
+  - [DOC]Replaced plugin_header file with plugin_header-integration file. [#46](https://github.com/logstash-plugins/logstash-integration-kafka/pull/46)
+  - [DOC]Update kafka client version across kafka integration docs [#47](https://github.com/logstash-plugins/logstash-integration-kafka/pull/47)
 
 ## 10.5.0
   - Changed: retry sending messages only for retriable exceptions [#27](https://github.com/logstash-plugins/logstash-integration-kafka/pull/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
   - [DOC]Replaced plugin_header file with plugin_header-integration file. [#46](https://github.com/logstash-plugins/logstash-integration-kafka/pull/46)
   - [DOC]Update kafka client version across kafka integration docs [#47](https://github.com/logstash-plugins/logstash-integration-kafka/pull/47)
   - [DOC]Replace hard-coded kafka client and doc path version numbers with attributes to simplify doc maintenance [#48](https://github.com/logstash-plugins/logstash-integration-kafka/pull/48)  
-  
-  
-  Replace hard-coded kafka client and doc path version numbers with attributes
-to simplify maintenance
 
 ## 10.5.0
   - Changed: retry sending messages only for retriable exceptions [#27](https://github.com/logstash-plugins/logstash-integration-kafka/pull/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 10.5.1
   - [DOC]Replaced plugin_header file with plugin_header-integration file. [#46](https://github.com/logstash-plugins/logstash-integration-kafka/pull/46)
   - [DOC]Update kafka client version across kafka integration docs [#47](https://github.com/logstash-plugins/logstash-integration-kafka/pull/47)
+  - [DOC]Replace hard-coded kafka client and doc path version numbers with attributes to simplify doc maintenance [#48](https://github.com/logstash-plugins/logstash-integration-kafka/pull/48)  
+  
+  
+  Replace hard-coded kafka client and doc path version numbers with attributes
+to simplify maintenance
 
 ## 10.5.0
   - Changed: retry sending messages only for retriable exceptions [#27](https://github.com/logstash-plugins/logstash-integration-kafka/pull/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.5.1
+  - DOC:Replaced plugin_header file with plugin_header-integration file. [#46](https://github.com/logstash-plugins/logstash-integration-kafka/pull/46)
+
 ## 10.5.0
   - Changed: retry sending messages only for retriable exceptions [#27](https://github.com/logstash-plugins/logstash-integration-kafka/pull/29)
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -1,3 +1,4 @@
+:integration: kafka
 :plugin: kafka
 :type: input
 :default_codec: plain

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Kafka input plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Kafka output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -1,3 +1,4 @@
+:integration: kafka
 :plugin: kafka
 :type: output
 :default_codec: plain

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.5.0'
+  s.version         = '10.5.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Integration plugins need a header that is different from the stand-alone plugin header.
The plugin docs should point to the integration repo rather than the
stand-alone input and output repo. We also add a note that the plugin
is part of an integration rather than stand-alone.

The new header included in this work was added with https://github.com/elastic/logstash/pull/11891 and https://github.com/elastic/logstash/pull/12163 for the Logstash Reference, and https://github.com/elastic/logstash-docs/pull/891 for the Versioned Plugin Reference.

