### PR TITLE
Avoid usage of SHUTDOWN event in Logstash 8.0.0 or greater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.7.1
+  - Fix: dropped usage of SHUTDOWN event deprecated since Logstash 5.0 [#71](https://github.com/logstash-plugins/logstash-integration-kafka/issue/71)
+  
 ## 10.7.0
   - Switched use from Faraday to Manticore as HTTP client library to access Schema Registry service 
     to fix issue [#63](https://github.com/logstash-plugins/logstash-integration-kafka/issue/63) 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -224,7 +224,6 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
     end
 
     events.each do |event|
-      break if event == LogStash::SHUTDOWN
       @codec.encode(event)
     end
 

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.0'
+  s.version         = '10.7.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
With PR https://github.com/elastic/logstash/pull/12517 the `SHUTDOWN` event has been removed, this PR avoid to use it if the plugin is running on Logstash 8.0.0 or greater