### PR TITLE
Upgade Jersey dependency to 2.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.7.2
+  - Update Jersey dependency to version 2.33 [#75](https://github.com/logstash-plugins/logstash-integration-kafka/pull/75)
+
 ## 10.7.1
   - Fix: dropped usage of SHUTDOWN event deprecated since Logstash 5.0 [#71](https://github.com/logstash-plugins/logstash-integration-kafka/issue/71)
   

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     }
     compile 'io.confluent:common-utils:5.5.1'
     compile 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-    compile 'org.glassfish.jersey.core:jersey-common:2.30'
+    compile 'org.glassfish.jersey.core:jersey-common:2.33'
     // given https://docs.confluent.io/current/installation/versions-interoperability.html matrix
     // Confluent Platform 5.5.x is Apache Kafka 2.5.x
     compile 'org.apache.kafka:kafka-clients:2.5.1'

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.1'
+  s.version         = '10.7.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Jersey version 2.31 fixes https://github.com/eclipse-ee4j/jersey/issues/3446, bump it to 2.33

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
