### PR TITLE
Improve Kafka input error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.7.5
+  - Improved error handling in the input plugin to avoid errors 'escaping' from the plugin, and crashing the logstash
+    process [#87](https://github.com/logstash-plugins/logstash-integration-kafka/pull/87)
+
 ## 10.7.4
   - Docs: make sure Kafka clients version is updated in docs [#83](https://github.com/logstash-plugins/logstash-integration-kafka/pull/83)
     Since **10.6.0** Kafka client was updated to **2.5.1**

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -309,7 +309,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         codec_instance = @codec.clone
         until stop?
           records = do_poll(consumer)
-            unless records.empty?
+          unless records.empty?
             records.each { |record| handle_record(record, codec_instance, logstash_queue) }
             maybe_commit_offset(consumer)
           end

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -253,6 +253,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   def register
     @runner_threads = []
     @metadata_mode = extract_metadata_level(@decorate_events)
+    @pattern ||= java.util.regex.Pattern.compile(@topics_pattern) unless @topics_pattern.nil?
     check_schema_registry_parameters
   end
 
@@ -260,7 +261,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   METADATA_BASIC    = Set[:record_props].freeze
   METADATA_EXTENDED = Set[:record_props, :headers].freeze
   METADATA_DEPRECATION_MAP = { 'true' => 'basic', 'false' => 'none' }
-
 
   def extract_metadata_level(decorate_events_setting)
     metadata_enabled = decorate_events_setting
@@ -297,12 +297,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     @runner_consumers
   end
 
-  def pattern
-    @pattern ||= java.util.regex.Pattern.compile(@topics_pattern) unless @topics_pattern.nil?
-  end
-
   def subscribe(consumer)
-    pattern.nil? ? consumer.subscribe(topics) : consumer.subscribe(pattern)
+    @pattern.nil? ? consumer.subscribe(topics) : consumer.subscribe(@pattern)
     consumer
   end
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -309,7 +309,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         codec_instance = @codec.clone
         until stop?
           records = do_poll(consumer)
-          unless records.nil? || records.count == 0
+            unless records.empty?
             records.each { |record| handle_record(record, codec_instance, logstash_queue) }
             maybe_commit_offset(consumer)
           end
@@ -321,7 +321,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   end
 
   def do_poll(consumer)
-    records = nil
+    records = []
     begin
       records = consumer.poll(poll_timeout_ms)
     rescue org.apache.kafka.common.errors.WakeupException => e

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -262,6 +262,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   METADATA_EXTENDED = Set[:record_props, :headers].freeze
   METADATA_DEPRECATION_MAP = { 'true' => 'basic', 'false' => 'none' }
 
+  private
   def extract_metadata_level(decorate_events_setting)
     metadata_enabled = decorate_events_setting
 
@@ -339,7 +340,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     codec_instance.decode(record.value.to_s) do |event|
       decorate(event)
       maybe_apply_schema(event, record)
-      maybe_apply_metadata(event, record)
+      maybe_set_metadata(event, record)
       queue << event
     end
   end
@@ -354,7 +355,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     end
   end
 
-  def maybe_apply_metadata(event, record)
+  def maybe_set_metadata(event, record)
     if @metadata_mode.include?(:record_props)
       event.set("[@metadata][kafka][topic]", record.topic)
       event.set("[@metadata][kafka][consumer_group]", @group_id)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -261,19 +261,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   METADATA_EXTENDED = Set[:record_props, :headers].freeze
   METADATA_DEPRECATION_MAP = { 'true' => 'basic', 'false' => 'none' }
 
-  private
-  def pattern
-    @pattern ||= java.util.regex.Pattern.compile(@topics_pattern) unless @topics_pattern.nil?
-  end
-
-  private
-  def subscribe(consumer)
-    unless pattern.nil?
-      consumer.subscribe(pattern)
-    else
-      consumer.subscribe(topics)
-    end
-  end
 
   def extract_metadata_level(decorate_events_setting)
     metadata_enabled = decorate_events_setting
@@ -293,9 +280,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def run(logstash_queue)
-    @runner_consumers = consumer_threads.times.map { |i| create_consumer("#{client_id}-#{i}") }
+    @runner_consumers = consumer_threads.times.map { |i| subscribe(create_consumer("#{client_id}-#{i}")) }
     @runner_threads = @runner_consumers.map { |consumer| thread_runner(logstash_queue, consumer) }
-    @runner_threads.each { |t| t.join }
+    @runner_threads.each(&:start)
+    @runner_threads.each(&:join)
   end # def run
 
   public
@@ -309,52 +297,100 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     @runner_consumers
   end
 
-  private
+  def pattern
+    @pattern ||= java.util.regex.Pattern.compile(@topics_pattern) unless @topics_pattern.nil?
+  end
+
+  def subscribe(consumer)
+    pattern.nil? ? consumer.subscribe(topics) : consumer.subscribe(pattern)
+    consumer
+  end
+
   def thread_runner(logstash_queue, consumer)
-    Thread.new do
+    java.lang.Thread.new do
       begin
         codec_instance = @codec.clone
-        while !stop?
-          records = consumer.poll(poll_timeout_ms)
-          next unless records.count > 0
-          for record in records do
-            codec_instance.decode(record.value.to_s) do |event|
-              decorate(event)
-              if schema_registry_url
-                json = LogStash::Json.load(record.value.to_s)
-                json.each do |k, v|
-                  event.set(k, v)
-                end
-                event.remove("message")
-              end
-              if @metadata_mode.include?(:record_props)
-                event.set("[@metadata][kafka][topic]", record.topic)
-                event.set("[@metadata][kafka][consumer_group]", @group_id)
-                event.set("[@metadata][kafka][partition]", record.partition)
-                event.set("[@metadata][kafka][offset]", record.offset)
-                event.set("[@metadata][kafka][key]", record.key)
-                event.set("[@metadata][kafka][timestamp]", record.timestamp)
-              end
-              if @metadata_mode.include?(:headers)
-                record.headers.each do |header|
-                  s = String.from_java_bytes(header.value)
-                  s.force_encoding(Encoding::UTF_8)
-                  if s.valid_encoding?
-                    event.set("[@metadata][kafka][headers]["+header.key+"]", s)
-                  end
-                end
-              end
-              logstash_queue << event
-            end
+        until stop?
+          records = do_poll(consumer)
+          unless records.nil? || records.count == 0
+            records.each { |record| handle_record(record, codec_instance, logstash_queue) }
+            maybe_commit_offset(consumer)
           end
-          # Manual offset commit
-          consumer.commitSync if @enable_auto_commit.eql?(false)
         end
-      rescue org.apache.kafka.common.errors.WakeupException => e
-        raise e if !stop?
       ensure
         consumer.close
       end
+    end
+  end
+
+  def do_poll(consumer)
+    records = nil
+    begin
+      records = consumer.poll(poll_timeout_ms)
+    rescue org.apache.kafka.common.errors.WakeupException => e
+      logger.debug("Wake up from poll", :kafka_error_message => e)
+      raise e unless stop?
+    rescue => e
+      logger.error("Unable to poll Kafka consumer",
+                   :kafka_error_message => e,
+                   :cause => e.respond_to?(:getCause) ? e.getCause : nil)
+      Stud.stoppable_sleep(1) { stop? }
+    end
+    records
+  end
+
+  def handle_record(record, codec_instance, queue)
+    codec_instance.decode(record.value.to_s) do |event|
+      decorate(event)
+      maybe_apply_schema(event, record)
+      maybe_apply_metadata(event, record)
+      queue << event
+    end
+  end
+
+  def maybe_apply_schema(event, record)
+    if schema_registry_url
+      json = LogStash::Json.load(record.value.to_s)
+      json.each do |k, v|
+        event.set(k, v)
+      end
+      event.remove("message")
+    end
+  end
+
+  def maybe_apply_metadata(event, record)
+    if @metadata_mode.include?(:record_props)
+      event.set("[@metadata][kafka][topic]", record.topic)
+      event.set("[@metadata][kafka][consumer_group]", @group_id)
+      event.set("[@metadata][kafka][partition]", record.partition)
+      event.set("[@metadata][kafka][offset]", record.offset)
+      event.set("[@metadata][kafka][key]", record.key)
+      event.set("[@metadata][kafka][timestamp]", record.timestamp)
+    end
+    if @metadata_mode.include?(:headers)
+      record.headers.each do |header|
+        s = String.from_java_bytes(header.value)
+        s.force_encoding(Encoding::UTF_8)
+        if s.valid_encoding?
+          event.set("[@metadata][kafka][headers][" + header.key + "]", s)
+        end
+      end
+    end
+  end
+
+  def maybe_commit_offset(consumer)
+    begin
+      consumer.commitSync if @enable_auto_commit.eql?(false)
+    rescue org.apache.kafka.common.errors.WakeupException => e
+      logger.debug("Wake up from commitSync", :kafka_error_message => e)
+      raise e unless stop?
+    rescue StandardError => e
+      # For transient errors, the commit should be successful after the next set of
+      # polled records has been processed.
+      # But, it might also be worth thinking about adding a configurable retry mechanism
+      logger.error("Unable to commit records",
+                   :kafka_error_message => e,
+                   :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
     end
   end
 
@@ -416,9 +452,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         set_sasl_config(props)
       end
 
-      consumer = org.apache.kafka.clients.consumer.KafkaConsumer.new(props)
-      subscribe(consumer)
-      consumer
+      org.apache.kafka.clients.consumer.KafkaConsumer.new(props)
     rescue => e
       logger.error("Unable to create Kafka consumer from given configuration",
                    :kafka_error_message => e,

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
   s.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'
-  s.add_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
+  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
   s.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'
-  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
+  s.add_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.4'
+  s.version         = '10.7.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -198,8 +198,9 @@ def consume_messages(config, queue: Queue.new, timeout:, event_count:)
     wait(timeout).for { queue.length }.to eq(event_count) unless timeout.eql?(false)
     block_given? ? yield(queue, kafka_input) : queue
   ensure
+    kafka_input.do_stop
     t.kill
-    t.join(30_000)
+    t.join(30)
   end
 end
 

--- a/spec/integration/outputs/kafka_spec.rb
+++ b/spec/integration/outputs/kafka_spec.rb
@@ -44,7 +44,7 @@ describe "outputs/kafka", :integration => true do
   end
 
   context 'when outputting messages serialized as Byte Array' do
-    let(:test_topic) { 'topic1b' }
+    let(:test_topic) { 'logstash_integration_topicbytearray' }
     let(:num_events) { 3 }
 
     before :each do

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -3,38 +3,160 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/kafka"
 require "concurrent"
 
-class MockConsumer
-  def initialize
-    @wake = Concurrent::AtomicBoolean.new(false)
+
+describe LogStash::Inputs::Kafka do
+  let(:common_config) { { 'topics' => ['logstash'], 'consumer_threads' => 1 } }
+  let(:config) { common_config }
+  let(:consumer_double) { double(:consumer) }
+  let(:payload) {
+    10.times.map do
+      org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "key", "value")
+    end
+  }
+  subject { LogStash::Inputs::Kafka.new(config) }
+
+  describe '#poll' do
+    before do
+    polled = false
+      allow(consumer_double).to receive(:poll) do
+        unless polled
+          polled = true
+          puts payload.class
+          payload
+        end
+      end
+    end
+
+    it 'should poll' do
+      expect(consumer_double).to receive(:poll)
+      expect(subject.do_poll(consumer_double)).to eq(payload)
+    end
+
+    it 'should return nil if Kafka Exception is encountered' do
+      expect(consumer_double).to receive(:poll).and_raise(org.apache.kafka.common.errors.TopicAuthorizationException.new(''))
+      expect(subject.do_poll(consumer_double)).to be_nil
+    end
+
+    it 'should not throw if Kafka Exception is encountered' do
+      expect(consumer_double).to receive(:poll).and_raise(org.apache.kafka.common.errors.TopicAuthorizationException.new(''))
+      expect{subject.do_poll(consumer_double)}.not_to raise_error
+    end
+
+    it 'should return no records if Assertion Error is encountered' do
+      expect(consumer_double).to receive(:poll).and_raise(java.lang.AssertionError.new(''))
+      expect{subject.do_poll(consumer_double)}.to raise_error(java.lang.AssertionError)
+    end
   end
 
-  def subscribe(topics)
-  end
-  
-  def poll(ms)
-    if @wake.value
-      raise org.apache.kafka.common.errors.WakeupException.new
-    else
-      10.times.map do
-        org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "key", "value")
+  describe '#maybe_commit_offset' do
+    context 'with auto commit disabled' do
+      let(:config) { common_config.merge('enable_auto_commit' => false) }
+
+      it 'should call commit on the consumer' do
+        expect(consumer_double).to receive(:commitSync)
+        subject.maybe_commit_offset(consumer_double)
+      end
+      it 'should not throw if a Kafka Exception is encountered' do
+        expect(consumer_double).to receive(:commitSync).and_raise(org.apache.kafka.common.errors.TopicAuthorizationException.new(''))
+        expect{subject.maybe_commit_offset(consumer_double)}.not_to raise_error
+      end
+
+      it 'should throw if Assertion Error is encountered' do
+        expect(consumer_double).to receive(:commitSync).and_raise(java.lang.AssertionError.new(''))
+        expect{subject.maybe_commit_offset(consumer_double)}.to raise_error(java.lang.AssertionError)
+      end
+    end
+
+    context 'with auto commit enabled' do
+      let(:config) { common_config.merge('enable_auto_commit' => true) }
+
+      it 'should not call commit on the consumer' do
+        expect(consumer_double).not_to receive(:commitSync)
+        subject.maybe_commit_offset(consumer_double)
       end
     end
   end
 
-  def close
+  describe '#register' do
+    it "should register" do
+      expect { subject.register }.to_not raise_error
+    end
   end
 
-  def wakeup
-    @wake.make_true
-  end
-end
+  describe '#running' do
+    before do
+      expect(subject).to receive(:create_consumer).once.and_return(consumer_double)
+      allow(consumer_double).to receive(:wakeup)
+      allow(consumer_double).to receive(:close)
+      allow(consumer_double).to receive(:subscribe)
+    end
+    it "should run" do
+      polled = false
+      allow(consumer_double).to receive(:poll) do
+        unless polled
+          polled = true
+          payload
+        end
+      end
 
-describe LogStash::Inputs::Kafka do
-  let(:config) { { 'topics' => ['logstash'], 'consumer_threads' => 4 } }
-  subject { LogStash::Inputs::Kafka.new(config) }
+      subject.register
+      q = Queue.new
+      Thread.new do
+        sleep(1)
+        subject.do_stop
+      end
+      subject.run(q)
 
-  it "should register" do
-    expect { subject.register }.to_not raise_error
+      expect(q.size).to eq(10)
+    end
+
+    it "should retry Kafka Exception" do
+      raised, polled = false
+
+      allow(consumer_double).to receive(:poll) do
+        unless raised
+          raised = true
+          raise org.apache.kafka.common.errors.TopicAuthorizationException.new('')
+        end
+        unless polled
+          polled = true
+          payload
+        end
+      end
+
+      subject.register
+      q = Queue.new
+      Thread.new do
+        sleep 3
+        subject.do_stop
+      end
+      subject.run(q)
+      expect(q.size).to eq(10)
+    end
+
+    it "should not retry Errors" do
+      raised, polled = false
+
+      allow(consumer_double).to receive(:poll) do
+        unless raised
+          raised = true
+          raise java.lang.AssertionError.new('')
+        end
+        unless polled
+          polled = true
+          payload
+        end
+      end
+
+      subject.register
+      q = Queue.new
+      Thread.new do
+        sleep 3
+        subject.do_stop
+      end
+      subject.run(q)
+      expect(q.size).to eq(0)
+    end
   end
 
   context "register parameter verification" do
@@ -132,3 +254,4 @@ describe LogStash::Inputs::Kafka do
     end
   end
 end
+

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -20,7 +20,9 @@ describe LogStash::Inputs::Kafka do
     before do
       polled = false
       allow(consumer_double).to receive(:poll) do
-        unless polled
+        if polled
+          []
+        else
           polled = true
           payload
         end
@@ -34,7 +36,7 @@ describe LogStash::Inputs::Kafka do
 
     it 'should return nil if Kafka Exception is encountered' do
       expect(consumer_double).to receive(:poll).and_raise(org.apache.kafka.common.errors.TopicAuthorizationException.new(''))
-      expect(subject.do_poll(consumer_double)).to be_nil
+      expect(subject.do_poll(consumer_double)).to be_empty
     end
 
     it 'should not throw if Kafka Exception is encountered' do
@@ -96,7 +98,9 @@ describe LogStash::Inputs::Kafka do
     it "should run" do
       polled = false
       allow(consumer_double).to receive(:poll) do
-        unless polled
+        if polled
+          []
+        else
           polled = true
           payload
         end
@@ -121,8 +125,9 @@ describe LogStash::Inputs::Kafka do
             raised = true
             raise exception
           end
-
-          unless polled
+          if polled
+            []
+          else
             polled = true
             payload
           end


### PR DESCRIPTION
This commit improves the error handling in the input side of this plugin by:

Adding begin...rescue blocks around the poll and commitSync methods in the polling thread to avoid handleable errors escaping out of the plugin.

Use Java threads instead of Ruby threads to enable the default uncaught exception handler to handle uncaught exceptions thrown in the polling thread, rather than deferring to the behavior determined by the value of `Thread.abort_on_exception`;  when this is set to true - as it currently is on `master` and `7.x` - such an error would cause Logstash execution to stop immediately across all pipelines. 

This commit does not current include any notion of backing off on errors. 