### PR TITLE
Improve wording on enable_auto_commit=false data safety

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -275,7 +275,8 @@ which the consumption will begin.
 
 If true, periodically commit to Kafka the offsets of messages already returned by
 the consumer. If value is `false` however, the offset is committed every time the
-consumer fetches the data from the topic.
+consumer fetches the data from the topic and the data is written to the in-memory
+or persistent queue.
 
 [id="plugins-{type}s-{plugin}-exclude_internal_topics"]
 ===== `exclude_internal_topics` 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -275,8 +275,7 @@ which the consumption will begin.
 
 If true, periodically commit to Kafka the offsets of messages already returned by
 the consumer. If value is `false` however, the offset is committed every time the
-consumer fetches the data from the topic and the data is written to the in-memory
-or persistent queue.
+consumer writes data fetched from the topic to the in-memory or persistent queue.
 
 [id="plugins-{type}s-{plugin}-exclude_internal_topics"]
 ===== `exclude_internal_topics` 


### PR DESCRIPTION
The current description of enable_auto_commit=false can lead to the interpretation that the commit happens right after data is fetched from a topic, while in truth that commit happens after that AND the data is written to the queue ([code here](https://github.com/logstash-plugins/logstash-integration-kafka/blob/master/lib/logstash/inputs/kafka.rb#L341-L345)).