### PR TITLE
Test: specify development dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.7.6
+  - Test: specify development dependency version [#91](https://github.com/logstash-plugins/logstash-integration-kafka/pull/91)
+
 ## 10.7.5
   - Improved error handling in the input plugin to avoid errors 'escaping' from the plugin, and crashing the logstash
     process [#87](https://github.com/logstash-plugins/logstash-integration-kafka/pull/87)

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.5'
+  s.version         = '10.7.6'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'
-  s.add_development_dependency 'ruby-kafka'
+  s.add_development_dependency 'digest-crc', '~> 0.5.1' # 0.6.0 started using a C-ext
+  s.add_development_dependency 'ruby-kafka' # depends on digest-crc
   s.add_development_dependency 'snappy'
 end


### PR DESCRIPTION
**digest-crc** since version 0.6.0 started using a [C-ext](https://github.com/postmodern/digest-crc/tree/v0.6.0/ext/digest)

this still works since the extension turns into a no-op on JRuby but the gem is still declared with:
```yaml
extensions:
- ext/digest/Rakefile
```
... which means the Rakefile will be triggered in an attempt to "build an extension"

being a test (development) dependency of ruby-kafka, 
forcing an olver ([extension-less](https://github.com/postmodern/digest-crc/tree/0.5.0)) version will effectively help the LS plugin install script to not run into issues.