### PR TITLE
Fix support for basic auth with the schema registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 10.7.7
-  - Fix: Correct the settings to allow basic auth to work properly, either by setting 'schema_registry_key/secret` or embedding username/password in the
+  - Fix: Correct the settings to allow basic auth to work properly, either by setting `schema_registry_key/secret` or embedding username/password in the
     url [#94](https://github.com/logstash-plugins/logstash-integration-kafka/pull/94)
 
 ## 10.7.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.7.7
+  - Fix: Correct the settings to allow basic auth to work properly, either by setting 'schema_registry_key/secret` or embedding username/password in the
+    url [#94](https://github.com/logstash-plugins/logstash-integration-kafka/pull/94)
+
 ## 10.7.6
   - Test: specify development dependency version [#91](https://github.com/logstash-plugins/logstash-integration-kafka/pull/91)
 

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -27,7 +27,6 @@ sleep 10
 echo "Downloading Confluent Platform"
 curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
-sed 's/8081/8082/' build/confluent_platform/etc/schema-registry/schema-registry.properties > build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.method=BASIC" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.roles=admin,developer,user,sr-user" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.realm=SchemaRegistry-Props" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
@@ -51,8 +50,5 @@ curl -s -o build/apache_logs.txt https://s3.amazonaws.com/data.elasticsearch.org
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_plain --broker-list localhost:9092
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_snappy --broker-list localhost:9092 --compression-codec snappy
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
-
-#./start_schema_registry.sh
-sleep 10
 
 echo "Setup complete, running specs"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -27,6 +27,12 @@ sleep 10
 echo "Downloading Confluent Platform"
 curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
+sed 's/8081/8082/' build/confluent_platform/etc/schema-registry/schema-registry.properties > build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
+echo "authentication.method=BASIC" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
+echo "authentication.roles=admin,developer,user,sr-user" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
+echo "authentication.realm=SchemaRegistry-Props" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
+cp spec/fixtures/jaas.config build/confluent_platform/etc/schema-registry
+cp spec/fixtures/pwd build/confluent_platform/etc/schema-registry
 
 echo "Setting up test topics with test data"
 build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_integration_topic_plain --zookeeper localhost:2181
@@ -46,8 +52,7 @@ cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic lo
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_snappy --broker-list localhost:9092 --compression-codec snappy
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
 
-echo "Starting SchemaRegistry"
-build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/schema-registry.properties > /dev/null 2>&1 &
+#./start_schema_registry.sh
 sleep 10
 
 echo "Setup complete, running specs"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -27,6 +27,7 @@ sleep 10
 echo "Downloading Confluent Platform"
 curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
+cp build/confluent_platform/etc/schema-registry/schema-registry.properties build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.method=BASIC" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.roles=admin,developer,user,sr-user" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.realm=SchemaRegistry-Props" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties

--- a/kafka_test_teardown.sh
+++ b/kafka_test_teardown.sh
@@ -2,9 +2,6 @@
 # Setup Kafka and create test topics
 set -ex
 
-echo "Stoppping SchemaRegistry"
-build/confluent_platform/bin/schema-registry-stop
-
 echo "Unregistering test topics"
 build/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --delete --topic 'logstash_integration_.*'
 build/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --delete --topic 'topic_avro.*'

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -433,13 +433,16 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       if schema_registry_url
         props.put(kafka::VALUE_DESERIALIZER_CLASS_CONFIG, Java::io.confluent.kafka.serializers.KafkaAvroDeserializer.java_class)
         serdes_config = Java::io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
-        props.put(serdes_config::SCHEMA_REGISTRY_URL_CONFIG, schema_registry_url.to_s)
+        props.put(serdes_config::SCHEMA_REGISTRY_URL_CONFIG, schema_registry_url.uri.to_s)
         if schema_registry_proxy && !schema_registry_proxy.empty?
           props.put(serdes_config::PROXY_HOST, @schema_registry_proxy_host)
           props.put(serdes_config::PROXY_PORT, @schema_registry_proxy_port)
         end
         if schema_registry_key && !schema_registry_key.empty?
+          props.put(serdes_config::BASIC_AUTH_CREDENTIALS_SOURCE, 'USER_INFO')
           props.put(serdes_config::USER_INFO_CONFIG, schema_registry_key + ":" + schema_registry_secret.value)
+        else
+          props.put(serdes_config::BASIC_AUTH_CREDENTIALS_SOURCE, 'URL')
         end
       end
       if security_protocol == "SSL"

--- a/lib/logstash/plugin_mixins/common.rb
+++ b/lib/logstash/plugin_mixins/common.rb
@@ -53,9 +53,8 @@ module LogStash
           options[:auth] = {:user => schema_registry_key, :password => schema_registry_secret.value}
         end
         client = Manticore::Client.new(options)
-
         begin
-          response = client.get(@schema_registry_url.to_s + '/subjects').body
+          response = client.get(@schema_registry_url.uri.to_s + '/subjects').body
         rescue Manticore::ManticoreException => e
           raise LogStash::ConfigurationError.new("Schema registry service doesn't respond, error: #{e.message}")
         end

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.6'
+  s.version         = '10.7.7'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/fixtures/jaas.config
+++ b/spec/fixtures/jaas.config
@@ -1,0 +1,5 @@
+SchemaRegistry-Props {
+  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+  file="build/confluent_platform/etc/schema-registry/pwd"
+  debug="true";
+};

--- a/spec/fixtures/pwd
+++ b/spec/fixtures/pwd
@@ -1,0 +1,5 @@
+fred: OBF:1w8t1tvf1w261w8v1w1c1tvn1w8x,user,admin
+barney: changeme,user,developer
+admin:admin,admin
+betty: MD5:164c88b302622e17050af52c89945d44,user
+wilma: CRYPT:adpexzg3FUZAk,admin,sr-user

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -206,6 +206,20 @@ end
 
 
 describe "schema registry connection options" do
+  schema_registry = Manticore::Client.new
+  before (:all) do
+    system('./stop_schema_registry.sh')
+    system('./start_schema_registry.sh')
+    Stud.try(20.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      expect(schema_registry.get("http://localhost:8081").code).to eq(200)
+    end
+
+  end
+
+  after(:all) do
+    system('./stop_schema_registry.sh')
+  end
+
   context "remote endpoint validation" do
     it "should fail if not reachable" do
       config = {'schema_registry_url' => 'http://localnothost:8081'}
@@ -232,8 +246,7 @@ describe "schema registry connection options" do
       end
 
       after(:each) do
-        schema_registry_client = Manticore::Client.new
-        delete_remote_schema(schema_registry_client, SUBJECT_NAME)
+        delete_remote_schema(schema_registry, SUBJECT_NAME)
       end
 
       it "should correctly complete registration phase" do
@@ -248,25 +261,35 @@ describe "schema registry connection options" do
   end
 end
 
-def save_avro_schema_to_schema_registry(schema_file, subject_name)
+def save_avro_schema_to_schema_registry(schema_file, subject_name, port=8081)
   raw_schema = File.readlines(schema_file).map(&:chomp).join
   raw_schema_quoted = raw_schema.gsub('"', '\"')
-  response = Manticore.post("http://localhost:8081/subjects/#{subject_name}/versions",
+  response = Manticore.post("http://localhost:#{port}/subjects/#{subject_name}/versions",
           body: '{"schema": "' + raw_schema_quoted + '"}',
           headers: {"Content-Type" => "application/vnd.schemaregistry.v1+json"})
   response
 end
 
-def delete_remote_schema(schema_registry_client, subject_name)
-  expect(schema_registry_client.delete("http://localhost:8081/subjects/#{subject_name}").code ).to be(200)
-  expect(schema_registry_client.delete("http://localhost:8081/subjects/#{subject_name}?permanent=true").code ).to be(200)
+def delete_remote_schema(schema_registry_client, subject_name,port=8081)
+  expect(schema_registry_client.delete("http://localhost:#{port}/subjects/#{subject_name}").code ).to be(200)
+  expect(schema_registry_client.delete("http://localhost:#{port}/subjects/#{subject_name}?permanent=true").code ).to be(200)
 end
 
 # AdminClientConfig = org.alpache.kafka.clients.admin.AdminClientConfig
 
 describe "Schema registry API", :integration => true do
+  schema_registry = Manticore::Client.new
+  before(:all) do
+    system('./stop_schema_registry.sh')
+    system('./start_schema_registry.sh')
+    Stud.try(20.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      expect(schema_registry.get("http://localhost:8081").code).to eq(200)
+    end
+  end
 
-  let(:schema_registry) { Manticore::Client.new }
+  after(:all) do
+    system('./stop_schema_registry.sh')
+  end
 
   context 'listing subject on clean instance' do
     it "should return an empty set" do
@@ -292,37 +315,44 @@ describe "Schema registry API", :integration => true do
       expect( subjects ).to be_empty
     end
   end
+end
 
-  context 'use the schema to serialize' do
+describe "Deserializing with the schema registry", :integration => true do
+  schema_registry = Manticore::Client.new
+
+  shared_examples 'it reads from a topic using a schema registry' do
     after(:each) do
-      expect( schema_registry.delete('http://localhost:8081/subjects/topic_avro-value').code ).to be(200)
+      expect( schema_registry.delete("#{subject_url}/#{avro_topic_name}-value").code ).to be(200)
       sleep 1
-      expect( schema_registry.delete('http://localhost:8081/subjects/topic_avro-value?permanent=true').code ).to be(200)
+      expect( schema_registry.delete("#{subject_url}/#{avro_topic_name}-value?permanent=true").code ).to be(200)
 
       Stud.try(3.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
         wait(10).for do
-          subjects = JSON.parse schema_registry.get('http://localhost:8081/subjects').body
+          subjects = JSON.parse schema_registry.get(subject_url).body
           subjects.empty?
         end.to be_truthy
       end
     end
 
-    let(:group_id_1) {rand(36**8).to_s(36)}
-
-    let(:avro_topic_name) { "topic_avro" }
-
-    let(:plain_config) do
-      { 'schema_registry_url' => 'http://localhost:8081',
-        'topics' => [avro_topic_name],
-        'codec' => 'plain',
-        'group_id' => group_id_1,
-        'auto_offset_reset' => 'earliest' }
+    let(:base_config) do
+      {
+          'topics' => [avro_topic_name],
+          'codec' => 'plain',
+          'group_id' => group_id_1,
+          'auto_offset_reset' => 'earliest'
+      }
     end
 
-    def delete_topic_if_exists(topic_name)
+    let(:group_id_1) {rand(36**8).to_s(36)}
+
+    def delete_topic_if_exists(topic_name, user = nil, password = nil)
       props = java.util.Properties.new
       props.put(Java::org.apache.kafka.clients.admin.AdminClientConfig::BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
-
+      serdes_config = Java::io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
+      unless user.nil?
+        props.put(serdes_config::BASIC_AUTH_CREDENTIALS_SOURCE, 'USER_INFO')
+        props.put(serdes_config::USER_INFO_CONFIG,  "#{user}:#{password}")
+      end
       admin_client = org.apache.kafka.clients.admin.AdminClient.create(props)
       topics_list = admin_client.listTopics().names().get()
       if topics_list.contains(topic_name)
@@ -331,14 +361,18 @@ describe "Schema registry API", :integration => true do
       end
     end
 
-    def write_some_data_to(topic_name)
+    def write_some_data_to(topic_name, port, user = nil, password = nil)
       props = java.util.Properties.new
       config = org.apache.kafka.clients.producer.ProducerConfig
 
       serdes_config = Java::io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
-      props.put(serdes_config::SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081")
+      props.put(serdes_config::SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:#{port}")
 
       props.put(config::BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+      unless user.nil?
+        props.put(serdes_config::BASIC_AUTH_CREDENTIALS_SOURCE, 'USER_INFO')
+        props.put(serdes_config::USER_INFO_CONFIG,  "#{user}:#{password}")
+      end
       props.put(config::KEY_SERIALIZER_CLASS_CONFIG, org.apache.kafka.common.serialization.StringSerializer.java_class)
       props.put(config::VALUE_SERIALIZER_CLASS_CONFIG, Java::io.confluent.kafka.serializers.KafkaAvroSerializer.java_class)
 
@@ -360,11 +394,11 @@ describe "Schema registry API", :integration => true do
     end
 
     it "stored a new schema using Avro Kafka serdes" do
-      delete_topic_if_exists avro_topic_name
-      write_some_data_to avro_topic_name
+      auth ? delete_topic_if_exists(avro_topic_name, user, password) : delete_topic_if_exists(avro_topic_name)
+      auth ? write_some_data_to(avro_topic_name, port, user, password) : write_some_data_to(avro_topic_name, port)
 
-      subjects = JSON.parse schema_registry.get('http://localhost:8081/subjects').body
-      expect( subjects ).to contain_exactly("topic_avro-value")
+      subjects = JSON.parse schema_registry.get(subject_url).body
+      expect( subjects ).to contain_exactly("#{avro_topic_name}-value")
 
       num_events = 1
       queue = consume_messages(plain_config, timeout: 30, event_count: num_events)
@@ -375,4 +409,56 @@ describe "Schema registry API", :integration => true do
       expect( elem.get("map_field")["inner_field"] ).to eq("inner value")
     end
   end
+  context 'with an unauthed schema registry' do
+    let(:port) { 8081 }
+    let(:auth) { false }
+    let(:avro_topic_name) { "topic_avro" }
+    let(:subject_url) { "http://localhost:#{port}/subjects" }
+    let(:plain_config)  { base_config.merge!({'schema_registry_url' => "http://localhost:#{port}"}) }
+
+    before (:all) do
+      system('./stop_schema_registry.sh')
+      system('./start_schema_registry.sh')
+      Stud.try(20.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+        expect(schema_registry.get("http://localhost:8081").code).to eq(200)
+      end
+    end
+
+    after(:all) do
+      system('./stop_schema_registry.sh')
+    end
+
+    it_behaves_like 'it reads from a topic using a schema registry'
+  end
+
+  context 'with an authed schema registry' do
+    let(:port) { 8082 }
+    let(:auth) { true }
+    let(:user) { "barney" }
+    let(:password) { "changeme" }
+    let(:avro_topic_name) { "topic_avro_auth" }
+    let(:subject_url) { "http://#{user}:#{password}@localhost:#{port}/subjects" }
+    let(:plain_config) do
+      base_config.merge!({
+                             'schema_registry_url' => "http://localhost:#{port}",
+                             'schema_registry_key' => user,
+                             'schema_registry_secret' => password
+                         })
+    end
+
+    before(:all) do
+      system('./stop_schema_registry.sh')
+      system('./start_auth_schema_registry.sh')
+      Stud.try(30.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+        expect(schema_registry.get("http://barney:changeme@localhost:8082").code).to eq(200)
+      end
+    end
+
+    after(:all) do
+      system('./stop_schema_registry.sh')
+    end
+
+    it_behaves_like 'it reads from a topic using a schema registry'
+  end
+
 end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -208,12 +208,12 @@ end
 describe "schema registry connection options" do
   schema_registry = Manticore::Client.new
   before (:all) do
-    cleanup_schema_registry
+    shutdown_schema_registry
     startup_schema_registry(schema_registry)
   end
 
   after(:all) do
-    cleanup_schema_registry
+    shutdown_schema_registry
   end
 
   context "remote endpoint validation" do
@@ -290,7 +290,7 @@ describe "Schema registry API", :integration => true do
   end
 
   after(:all) do
-    cleanup_schema_registry
+    shutdown_schema_registry
   end
 
   context 'listing subject on clean instance' do
@@ -319,7 +319,7 @@ describe "Schema registry API", :integration => true do
   end
 end
 
-def cleanup_schema_registry
+def shutdown_schema_registry
   system('./stop_schema_registry.sh')
 end
 
@@ -329,12 +329,12 @@ describe "Deserializing with the schema registry", :integration => true do
   shared_examples 'it reads from a topic using a schema registry' do |with_auth|
 
     before(:all) do
-      cleanup_schema_registry
+      shutdown_schema_registry
       startup_schema_registry(schema_registry, with_auth)
     end
 
     after(:all) do
-      cleanup_schema_registry
+      shutdown_schema_registry
     end
 
     after(:each) do

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -432,7 +432,7 @@ describe "Deserializing with the schema registry", :integration => true do
   end
 
   context 'with an authed schema registry' do
-    let(:port) { 8082 }
+    let(:port) { 8081 }
     let(:auth) { true }
     let(:user) { "barney" }
     let(:password) { "changeme" }
@@ -450,7 +450,7 @@ describe "Deserializing with the schema registry", :integration => true do
       system('./stop_schema_registry.sh')
       system('./start_auth_schema_registry.sh')
       Stud.try(30.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
-        expect(schema_registry.get("http://barney:changeme@localhost:8082").code).to eq(200)
+        expect(schema_registry.get("http://barney:changeme@localhost:8081").code).to eq(200)
       end
     end
 

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -326,11 +326,11 @@ end
 describe "Deserializing with the schema registry", :integration => true do
   schema_registry = Manticore::Client.new
 
-  shared_examples 'it reads from a topic using a schema registry' do
+  shared_examples 'it reads from a topic using a schema registry' do |with_auth|
 
     before(:all) do
       cleanup_schema_registry
-      startup_schema_registry(schema_registry, auth)
+      startup_schema_registry(schema_registry, with_auth)
     end
 
     after(:all) do
@@ -432,7 +432,7 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:subject_url) { "http://localhost:8081/subjects" }
     let(:plain_config)  { base_config.merge!({'schema_registry_url' => "http://localhost:8081"}) }
 
-    it_behaves_like 'it reads from a topic using a schema registry'
+    it_behaves_like 'it reads from a topic using a schema registry', false
   end
 
   context 'with an authed schema registry' do
@@ -451,7 +451,7 @@ describe "Deserializing with the schema registry", :integration => true do
         })
       end
 
-      it_behaves_like 'it reads from a topic using a schema registry'
+      it_behaves_like 'it reads from a topic using a schema registry', true
     end
 
     context 'using schema_registry_url' do
@@ -461,7 +461,7 @@ describe "Deserializing with the schema registry", :integration => true do
         })
       end
 
-      it_behaves_like 'it reads from a topic using a schema registry'
+      it_behaves_like 'it reads from a topic using a schema registry', true
     end
   end
 end

--- a/start_auth_schema_registry.sh
+++ b/start_auth_schema_registry.sh
@@ -3,4 +3,4 @@
 set -ex
 
 echo "Starting authed SchemaRegistry"
-SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=$PWD/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties > /dev/null 2>&1 &
+SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties > /dev/null 2>&1 &

--- a/start_auth_schema_registry.sh
+++ b/start_auth_schema_registry.sh
@@ -3,4 +3,4 @@
 set -ex
 
 echo "Starting authed SchemaRegistry"
-SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
+SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties  > /dev/null 2>&1 &

--- a/start_auth_schema_registry.sh
+++ b/start_auth_schema_registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Starting authed SchemaRegistry"
+SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=$PWD/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties > /dev/null 2>&1 &

--- a/start_auth_schema_registry.sh
+++ b/start_auth_schema_registry.sh
@@ -3,4 +3,4 @@
 set -ex
 
 echo "Starting authed SchemaRegistry"
-SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties > /dev/null 2>&1 &
+SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/authed-schema-registry.properties

--- a/start_schema_registry.sh
+++ b/start_schema_registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Starting SchemaRegistry"
+build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/schema-registry.properties > /dev/null 2>&1 &

--- a/stop_schema_registry.sh
+++ b/stop_schema_registry.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Stoppping SchemaRegistry"
+build/confluent_platform/bin/schema-registry-stop
+sleep 5


### PR DESCRIPTION
This fixes an issue with supporting basic auth when using the schema registry

The plugin currently expects `schema_registry_secret` and `schema_registry_key` to
be set to authenticate with the schema registry. However, while this works during the
'register' phase, the authentication type `basic.auth.credentials.source` is not set
when creating the kafka consumer, leading to authentication failures when attempting
to deserialize the kafka payload.

This commit correctly sets the `basic.auth.credentials.source` to `USER_INFO` when
`schema_registry_key` and `schema_registry_secret` are set, and also enables the use
of a basic auth embedded in the `schema_registry_url` via `username:password@url`
