### PR TITLE
Add option to skip validation when dealing with schema registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.8.0
+  - Added config setting to enable schema registry validation to be skipped when an authentication scheme unsupported
+    by the validator is used [#97](https://github.com/logstash-plugins/logstash-integration-kafka/pull/97)
+
 ## 10.7.7
   - Fix: Correct the settings to allow basic auth to work properly, either by setting `schema_registry_key/secret` or embedding username/password in the
     url [#94](https://github.com/logstash-plugins/logstash-integration-kafka/pull/94)

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -577,7 +577,7 @@ The schemas must follow a naming convention with the pattern <topic name>-value.
 Use either the Schema Registry config option or the
 <<plugins-{type}s-{plugin}-value_deserializer_class>> config option, but not both.
 
-[id="plugins-{type}s-{plugin}-validate_schema_registry"]
+[id="plugins-{type}s-{plugin}-schema_registry_validation"]
 ===== `schema_registry_validation`
 
   * Value can be either of: `auto`, `skip`

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -585,11 +585,9 @@ Use either the Schema Registry config option or the
 
 NOTE: Under most circumstances, the default setting of `auto` should not need to be changed.
 
-When using the schema registry, by default a validation process to check connectivity and
-the validity of the schema registry takes place during plugin registration. Under certain
-circumstances when trying to validate an authenticated schema registry, this process may
-fail, and cause the plugin to crash. This setting allows this validation to be skipped during
-registration.
+When using the schema registry, by default the plugin checks connectivity and validates the schema registry, during plugin registration, before events are processed.
+In some circumstances, this process may fail when it tries to validate an authenticated schema registry, causing the plugin to crash.
+This setting allows the plugin to skip validation during registration, which allows the plugin to continue and events to be processed. Note that an incorrectly configured schema registry will still stop the plugin from processing events.
 
 [id="plugins-{type}s-{plugin}-security_protocol"]
 ===== `security_protocol` 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -128,6 +128,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-schema_registry_proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_secret>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_url>> |<<uri,uri>>|No
+| <<plugins-{type}s-{plugin}-schema_registry_validation>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
 | <<plugins-{type}s-{plugin}-send_buffer_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-session_timeout_ms>> |<<number,number>>|No
@@ -575,6 +576,20 @@ The schemas must follow a naming convention with the pattern <topic name>-value.
 
 Use either the Schema Registry config option or the
 <<plugins-{type}s-{plugin}-value_deserializer_class>> config option, but not both.
+
+[id="plugins-{type}s-{plugin}-validate_schema_registry"]
+===== `schema_registry_validation`
+
+  * Value can be either of: `auto`, `skip`
+  * Default value is `"auto"`
+
+NOTE: Under most circumstances, the default setting of `auto` should not need to be changed.
+
+When using the schema registry, by default a validation process to check connectivity and
+the validity of the schema registry takes place during plugin registration. Under certain
+circumstances when trying to validate an authenticated schema registry, this process may
+fail, and cause the plugin to crash. This setting allows this validation to be skipped during
+registration.
 
 [id="plugins-{type}s-{plugin}-security_protocol"]
 ===== `security_protocol` 

--- a/lib/logstash/plugin_mixins/common.rb
+++ b/lib/logstash/plugin_mixins/common.rb
@@ -39,7 +39,9 @@ module LogStash
 
       def schema_registry_validation?
         return false if schema_registry_validation.to_s == 'skip'
-        !using_kerberos?
+        return false if using_kerberos? # pre-validation doesn't support kerberos
+        
+        true
       end
 
       def using_kerberos?

--- a/lib/logstash/plugin_mixins/common.rb
+++ b/lib/logstash/plugin_mixins/common.rb
@@ -25,7 +25,7 @@ module LogStash
 
         # Option to skip validating the schema registry during registration. This can be useful when using
         # certificate based auth
-        config :validate_schema_registry, :validate => ['auto', 'skip'], :default => 'auto'
+        config :schema_registry_validation, :validate => ['auto', 'skip'], :default => 'auto'
       end
 
       def check_schema_registry_parameters
@@ -33,12 +33,12 @@ module LogStash
           check_for_schema_registry_conflicts
           @schema_registry_proxy_host, @schema_registry_proxy_port  = split_proxy_into_host_and_port(schema_registry_proxy)
           check_for_key_and_secret
-          check_for_schema_registry_connectivity_and_subjects if validate_schema_registry?
+          check_for_schema_registry_connectivity_and_subjects if schema_registry_validation?
         end
       end
 
-      def validate_schema_registry?
-        return false if validate_schema_registry.to_s == 'skip'
+      def schema_registry_validation?
+        return false if schema_registry_validation.to_s == 'skip'
         !using_kerberos?
       end
 

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.7.7'
+  s.version         = '10.8.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -177,11 +177,16 @@ describe LogStash::Inputs::Kafka do
     end
   end
 
-  context "register parameter verification" do
+  describe "schema registry parameter verification" do
+    let(:base_config) do {
+          'schema_registry_url' => 'http://localhost:8081',
+          'topics' => ['logstash'],
+          'consumer_threads' => 4
+    }
+    end
+
     context "schema_registry_url" do
-      let(:config) do
-        { 'schema_registry_url' => 'http://localhost:8081', 'topics' => ['logstash'], 'consumer_threads' => 4 }
-      end
+     let(:config) { base_config }
 
       it "conflict with value_deserializer_class should fail" do
         config['value_deserializer_class'] = 'my.fantasy.Deserializer'
@@ -194,7 +199,52 @@ describe LogStash::Inputs::Kafka do
       end
     end
 
-    context "decorate_events" do
+    context 'when kerberos auth is used' do
+      ['SASL_SSL', 'SASL_PLAINTEXT'].each do |protocol|
+        context "with #{protocol}" do
+          ['auto', 'skip'].each do |vsr|
+            context "when validata_schema_registry is #{vsr}" do
+              let(:config) { base_config.merge({'security_protocol' => protocol,
+                                                'validate_schema_registry' => vsr})
+              }
+              it 'should skip verification' do
+                expect(subject).not_to receive(:check_for_schema_registry_connectivity_and_subjects)
+                expect { subject.register }.not_to raise_error
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when kerberos auth is not used' do
+      context "when skip_verify is set to auto" do
+        let(:config) { base_config.merge({'validate_schema_registry' => 'auto'})}
+        it 'should not skip verification' do
+          expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
+          expect { subject.register }.not_to raise_error
+        end
+      end
+
+      context "when skip_verify is set to default" do
+        let(:config) { base_config }
+        it 'should not skip verification' do
+          expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
+          expect { subject.register }.not_to raise_error
+        end
+      end
+
+      context "when skip_verify is set to skip" do
+        let(:config) { base_config.merge({'validate_schema_registry' => 'skip'})}
+        it 'should skip verification' do
+          expect(subject).not_to receive(:check_for_schema_registry_connectivity_and_subjects)
+          expect { subject.register }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  context "decorate_events" do
       let(:config) { { 'decorate_events' => 'extended'} }
 
       it "should raise error for invalid value" do
@@ -208,7 +258,6 @@ describe LogStash::Inputs::Kafka do
         expect(subject.metadata_mode).to include(:record_props)
       end
     end
-  end
 
   context 'with client_rack' do
     let(:config) { super().merge('client_rack' => 'EU-R1') }

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -205,7 +205,7 @@ describe LogStash::Inputs::Kafka do
           ['auto', 'skip'].each do |vsr|
             context "when validata_schema_registry is #{vsr}" do
               let(:config) { base_config.merge({'security_protocol' => protocol,
-                                                'validate_schema_registry' => vsr})
+                                                'schema_registry_validation' => vsr})
               }
               it 'should skip verification' do
                 expect(subject).not_to receive(:check_for_schema_registry_connectivity_and_subjects)
@@ -219,7 +219,7 @@ describe LogStash::Inputs::Kafka do
 
     context 'when kerberos auth is not used' do
       context "when skip_verify is set to auto" do
-        let(:config) { base_config.merge({'validate_schema_registry' => 'auto'})}
+        let(:config) { base_config.merge({'schema_registry_validation' => 'auto'})}
         it 'should not skip verification' do
           expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
           expect { subject.register }.not_to raise_error
@@ -235,7 +235,7 @@ describe LogStash::Inputs::Kafka do
       end
 
       context "when skip_verify is set to skip" do
-        let(:config) { base_config.merge({'validate_schema_registry' => 'skip'})}
+        let(:config) { base_config.merge({'schema_registry_validation' => 'skip'})}
         it 'should skip verification' do
           expect(subject).not_to receive(:check_for_schema_registry_connectivity_and_subjects)
           expect { subject.register }.not_to raise_error

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -207,7 +207,7 @@ describe LogStash::Inputs::Kafka do
               let(:config) { base_config.merge({'security_protocol' => protocol,
                                                 'schema_registry_validation' => vsr})
               }
-              it 'should skip verification' do
+              it 'skips verification' do
                 expect(subject).not_to receive(:check_for_schema_registry_connectivity_and_subjects)
                 expect { subject.register }.not_to raise_error
               end
@@ -220,7 +220,7 @@ describe LogStash::Inputs::Kafka do
     context 'when kerberos auth is not used' do
       context "when skip_verify is set to auto" do
         let(:config) { base_config.merge({'schema_registry_validation' => 'auto'})}
-        it 'should not skip verification' do
+        it 'performs verification' do
           expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
           expect { subject.register }.not_to raise_error
         end
@@ -228,7 +228,7 @@ describe LogStash::Inputs::Kafka do
 
       context "when skip_verify is set to default" do
         let(:config) { base_config }
-        it 'should not skip verification' do
+        it 'performs verification' do
           expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
           expect { subject.register }.not_to raise_error
         end
@@ -245,19 +245,19 @@ describe LogStash::Inputs::Kafka do
   end
 
   context "decorate_events" do
-      let(:config) { { 'decorate_events' => 'extended'} }
+    let(:config) { { 'decorate_events' => 'extended'} }
 
-      it "should raise error for invalid value" do
-        config['decorate_events'] = 'avoid'
-        expect { subject.register }.to raise_error LogStash::ConfigurationError, /Something is wrong with your configuration./
-      end
-
-      it "should map old true boolean value to :record_props mode" do
-        config['decorate_events'] = "true"
-        subject.register
-        expect(subject.metadata_mode).to include(:record_props)
-      end
+    it "should raise error for invalid value" do
+      config['decorate_events'] = 'avoid'
+      expect { subject.register }.to raise_error LogStash::ConfigurationError, /Something is wrong with your configuration./
     end
+
+    it "should map old true boolean value to :record_props mode" do
+      config['decorate_events'] = "true"
+      subject.register
+      expect(subject.metadata_mode).to include(:record_props)
+    end
+  end
 
   context 'with client_rack' do
     let(:config) { super().merge('client_rack' => 'EU-R1') }


### PR DESCRIPTION
This PR adds a `validate_schema_registry` option to the plugin, allowing
users to bypass the schema registry validation while using a plugin. This is
a common issue when using authenticated schema registry, as the validation occurs
outside of the 'KafkaConsumer' code, and will require considerable effort to maintain
parity with that method.

This configuration option has 2 settings `auto` and `skip`. The default `auto` setting
will skip validation when schema registry auth is used that is known to fail, currently
when Kerberos authentication is used, but will try and validate in other cases. `skip`
will skip regardless of authentication method.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
