### PR TITLE
Doc: Remove outdated recommendation for settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.8.1
+  - [DOC] Removed a setting recommendation that is no longer applicable for Kafka 2.0+ [#99](https://github.com/logstash-plugins/logstash-integration-kafka/pull/99)
+
 ## 10.8.0
   - Added config setting to enable schema registry validation to be skipped when an authentication scheme unsupported
     by the validator is used [#97](https://github.com/logstash-plugins/logstash-integration-kafka/pull/97)

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -415,7 +415,6 @@ The maximum delay between invocations of poll() when using consumer group manage
 an upper bound on the amount of time that the consumer can be idle before fetching more records. 
 If poll() is not called before expiration of this timeout, then the consumer is considered failed and 
 the group will rebalance in order to reassign the partitions to another member.
-The value of the configuration `request_timeout_ms` must always be larger than `max_poll_interval_ms`. ???
 
 [id="plugins-{type}s-{plugin}-max_poll_records"]
 ===== `max_poll_records` 

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.8.0'
+  s.version         = '10.8.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Remove a setting recommendation that is no longer accurate for Kafka 2.0+. 

Fixes: #20
