### PR TITLE
Refactor: leverage codec when using schema registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.9.0
+  - Refactor: leverage codec when using schema registry [#106](https://github.com/logstash-plugins/logstash-integration-kafka/pull/106)
+
 ## 10.8.2
   - [DOC] Updates description of `enable_auto_commit=false` to clarify that the commit happens after data is fetched AND written to the queue [#90](https://github.com/logstash-plugins/logstash-integration-kafka/pull/90)
   - Fix: update to Gradle 7 [#104](https://github.com/logstash-plugins/logstash-integration-kafka/pull/104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 10.9.0
   - Refactor: leverage codec when using schema registry [#106](https://github.com/logstash-plugins/logstash-integration-kafka/pull/106)
+  
+    Previously using `schema_registry_url` parsed the payload as JSON even if `codec => 'plain'` was set, this is no longer the case.  
 
 ## 10.8.2
   - [DOC] Updates description of `enable_auto_commit=false` to clarify that the commit happens after data is fetched AND written to the queue [#90](https://github.com/logstash-plugins/logstash-integration-kafka/pull/90)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -63,7 +63,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   config_name 'kafka'
 
-  default :codec, 'plain'
+  # default :codec, 'plain' or 'json' depending whether schema registry is used
+  #
+  # @override LogStash::Inputs::Base - removing the `:default => :plain`
+  config :codec, :validate => :codec # default: plain or json (when using schema_registry)
 
   # The frequency in milliseconds that the consumer offsets are committed to Kafka.
   config :auto_commit_interval_ms, :validate => :number, :default => 5000 # Kafka default
@@ -249,6 +252,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   attr_reader :metadata_mode
 
+  def initialize(params = {})
+    unless params.key?('codec')
+      params['codec'] = params.key?('schema_registry_url') ? 'json' : 'plain'
+    end
+
+    super(params)
+  end
+
   public
   def register
     @runner_threads = []
@@ -341,19 +352,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   def handle_record(record, codec_instance, queue)
     codec_instance.decode(record.value.to_s) do |event|
       decorate(event)
-      maybe_apply_schema(event, record)
       maybe_set_metadata(event, record)
       queue << event
-    end
-  end
-
-  def maybe_apply_schema(event, record)
-    if schema_registry_url
-      json = LogStash::Json.load(record.value.to_s)
-      json.each do |k, v|
-        event.set(k, v)
-      end
-      event.remove("message")
     end
   end
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -66,7 +66,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # default :codec, 'plain' or 'json' depending whether schema registry is used
   #
   # @override LogStash::Inputs::Base - removing the `:default => :plain`
-  config :codec, :validate => :codec # default: plain or json (when using schema_registry)
+  config :codec, :validate => :codec
+  # NOTE: isn't necessary due the params['codec'] = ... done in #initialize
+  # having the `nil` default explicit makes the behavior more noticeable.
 
   # The frequency in milliseconds that the consumer offsets are committed to Kafka.
   config :auto_commit_interval_ms, :validate => :number, :default => 5000 # Kafka default
@@ -252,6 +254,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   attr_reader :metadata_mode
 
+  # @overload based on schema registry change the codec default
   def initialize(params = {})
     unless params.key?('codec')
       params['codec'] = params.key?('schema_registry_url') ? 'json' : 'plain'

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '10.8.2'
+  s.version         = '10.9.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-line'
   s.add_development_dependency 'rspec-wait'
   s.add_development_dependency 'digest-crc', '~> 0.5.1' # 0.6.0 started using a C-ext
   s.add_development_dependency 'ruby-kafka' # depends on digest-crc

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -16,38 +16,38 @@ describe "inputs/kafka", :integration => true do
   let(:group_id_5) {rand(36**8).to_s(36)}
   let(:group_id_6) {rand(36**8).to_s(36)}
   let(:plain_config) do
-    { 'topics' => ['logstash_integration_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_1,
+    { 'topics' => ['logstash_integration_topic_plain'], 'group_id' => group_id_1,
       'auto_offset_reset' => 'earliest' }
   end
   let(:multi_consumer_config) do
     plain_config.merge({"group_id" => group_id_4, "client_id" => "spec", "consumer_threads" => 3})
   end
   let(:snappy_config) do
-    { 'topics' => ['logstash_integration_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id_1,
+    { 'topics' => ['logstash_integration_topic_snappy'], 'group_id' => group_id_1,
       'auto_offset_reset' => 'earliest' }
   end
   let(:lz4_config) do
-    { 'topics' => ['logstash_integration_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id_1,
+    { 'topics' => ['logstash_integration_topic_lz4'], 'group_id' => group_id_1,
       'auto_offset_reset' => 'earliest' }
   end
   let(:pattern_config) do
-    { 'topics_pattern' => 'logstash_integration_topic_.*', 'group_id' => group_id_2, 'codec' => 'plain',
+    { 'topics_pattern' => 'logstash_integration_topic_.*', 'group_id' => group_id_2,
       'auto_offset_reset' => 'earliest' }
   end
   let(:decorate_config) do
-    { 'topics' => ['logstash_integration_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_3,
+    { 'topics' => ['logstash_integration_topic_plain'], 'group_id' => group_id_3,
       'auto_offset_reset' => 'earliest', 'decorate_events' => 'true' }
   end
   let(:decorate_headers_config) do
-    { 'topics' => ['logstash_integration_topic_plain_with_headers'], 'codec' => 'plain', 'group_id' => group_id_3,
+    { 'topics' => ['logstash_integration_topic_plain_with_headers'], 'group_id' => group_id_3,
       'auto_offset_reset' => 'earliest', 'decorate_events' => 'extended' }
   end
   let(:decorate_bad_headers_config) do
-    { 'topics' => ['logstash_integration_topic_plain_with_headers_badly'], 'codec' => 'plain', 'group_id' => group_id_3,
+    { 'topics' => ['logstash_integration_topic_plain_with_headers_badly'], 'group_id' => group_id_3,
       'auto_offset_reset' => 'earliest', 'decorate_events' => 'extended' }
   end
   let(:manual_commit_config) do
-    { 'topics' => ['logstash_integration_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_5,
+    { 'topics' => ['logstash_integration_topic_plain'], 'group_id' => group_id_5,
       'auto_offset_reset' => 'earliest', 'enable_auto_commit' => 'false' }
   end
   let(:timeout_seconds) { 30 }
@@ -352,10 +352,7 @@ describe "Deserializing with the schema registry", :integration => true do
 
     let(:base_config) do
       {
-          'topics' => [avro_topic_name],
-          'codec' => 'plain',
-          'group_id' => group_id_1,
-          'auto_offset_reset' => 'earliest'
+          'topics' => [avro_topic_name], 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'
       }
     end
 


### PR DESCRIPTION
The motivation here is to be able to leverage the proper codec in all scenarios the plugin operates.

The default behavior for the Kafka input is to use the plain codec and decode the record payload.
With the `schema_registry_url` the codec is still used but the payload is than parsed again as json.

The PR changes the behavior with some clever hooks into `Plugin#initialize` to change the default codec:
- when user specifies `schema_registry_url` default to using the json codec
- when `schema_registry_url` is not specified default to the plain codec
- when the user specified a `codec` option use that regardless of `schema_registry_url`

NOTE: PR's changes cause a slight regression, previously the plugin worked fine using `schema_registry_url` when a codec (e.g. `codec => plain`) was also specified - since json parsing was done manually regardless of the codec.

---

The changes are sufficient given that `ecs_compatibility` is either local or a global setting -> JSON codec default in case of the schema registry will already warn users on a missing target e.g. 

```
[2021-12-06T12:55:15,785][INFO ][org.reflections.Reflections] Reflections took 116 ms to scan 1 urls, producing 119 keys and 416 values 
[2021-12-06T12:55:16,222][INFO ][logstash.codecs.json     ] ECS compatibility is enabled but `target` option was not specified. This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant or non-conflicting, feel free to ignore this message)
[2021-12-06T12:55:16,646][INFO ][logstash.javapipeline    ] Pipeline `main` is configured with `pipeline.ecs_compatibility: v8` setting. All plugins in this pipeline will default to `ecs_compatibility => v8` unless explicitly configured otherwise.
[2021-12-06T12:55:16,786][INFO ][logstash.javapipeline    ][main] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>16, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>2000, "pipeline.sources"=>["config string"], :thread=>"#<Thread:0x7a8ed04a run>"}

```