### PR TITLE
Fix(docs): Discourage should be about changing defaults, not using them

### DIFF
--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -333,7 +333,7 @@ retries are exhausted.
   * There is no default value for this setting.
 
 The default retry behavior is to retry until successful. To prevent data loss,
-the use of this setting is discouraged.
+changing this setting is discouraged.
 
 If you choose to set `retries`, a value greater than zero will cause the
 client to only retry a fixed number of times. This will result in data loss


### PR DESCRIPTION
While I can't read minds, I am fairly certain that what is *discouraged* here is to change this default setting, not to use the default setting.

I think it's fair to assume that no product would ship with default settings that are discouraged. So I submit this fix to make the documentation match the intention.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
