### PR TITLE
Implement the `static membership` feature to Kafka input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 11.1.0
  - Added config `group_instance_id` to use the Kafka's consumer static membership feature [#135](https://github.com/logstash-plugins/logstash-integration-kafka/pull/135)
 
 ## 11.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+ - Added config `group_instance_id` to use the Kafka's consumer static membership feature [#135](https://github.com/logstash-plugins/logstash-integration-kafka/pull/135)
+
 ## 11.0.0
   - Changed Kafka client to 3.3.1, requires Logstash >= 8.3.0. 
   - Deprecated `default` value for setting `client_dns_lookup` forcing to `use_all_dns_ips` when explicitly used [#130](https://github.com/logstash-plugins/logstash-integration-kafka/pull/130)

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -359,7 +359,9 @@ This mitigates the cases where the service state is heavy and rebalance of one t
 A to B means huge amount of data transfer. Client that goes offline and online frequently, if using this settings
 avoid frequent and heavy rebalances.
 
-NOTE: In case another client connects with same `group.instance.id` value then the oldest is kicked off.
+NOTE: It has to be unique across all the clients connected to same topic, in case another client connects
+with same `group.instance.id` value then the oldest is kicked off.
+Generally could be something like a hostname, an IP or anything that uniquely identifies the client application.
 
 NOTE: In cases when multiple threads are configured, `consumer_threads` is greater than one, a suffix is appended to
 the `group_instance_id` to avoid collisions.

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -113,6 +113,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-fetch_max_wait_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-fetch_min_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-group_id>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-group_instance_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-heartbeat_interval_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-isolation_level>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-jaas_path>> |a valid filesystem path|No
@@ -343,6 +344,25 @@ Logstash instances with the same `group_id`.
 NOTE: In cases when multiple inputs are being used in a single pipeline, reading from different topics,
 it's essential to set a different `group_id => ...` for each input. Setting a unique `client_id => ...`
 is also recommended.
+
+[id="plugins-{type}s-{plugin}-group_instance_id"]
+===== `group_instance_id`
+
+* Value type is <<string,string>>
+* Optional, there is no default value for this setting.
+
+The static membership identifier for this consumer. Static membership feature was introduced in
+https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances[KIP-345],
+available under Kafka property `group.instance.id` and aims to avoid rebalances in contexts where a lot of data
+has to be handed off after a consumer goes offline.
+This mitigates the cases where the service state is heavy and rebalance of one topic partition from instance
+A to B means huge amount of data transfer. Client that goes offline and online frequently, if using this settings
+avoid frequent and heavy rebalances.
+
+NOTE: In case another client connects with same `group.instance.id` value then the oldest is kicked off.
+
+NOTE: In cases when multiple threads are configured, `consumer_threads` is greater than one, a suffix is appended to
+the `group_instance_id` to avoid collisions.
 
 [id="plugins-{type}s-{plugin}-heartbeat_interval_ms"]
 ===== `heartbeat_interval_ms` 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -360,8 +360,8 @@ This feature mitigates cases where the service state is heavy and the rebalance 
 A to B would cause a huge amount of data to be transferred.
 A client that goes offline/online frequently can avoid frequent and heavy rebalances by using this option.
 
-NOTE: It has to be unique across all the clients belonging to the same <<plugins-{type}s-{plugin}-group_id>>, in case another client connects
-with same `group.instance.id` value then the oldest is kicked off.
+NOTE: The `group_instance_id` setting must be unique across all the clients belonging to the same <<plugins-{type}s-{plugin}-group_id>>.
+Otherwise, another client connecting with same `group.instance.id` value would cause the oldest instance to be disconnected.
 You can set this value to use information such as a hostname, an IP, or anything that uniquely identifies the client application.
 
 NOTE: In cases when multiple threads are configured and `consumer_threads` is greater than one, a suffix is appended to

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -359,7 +359,7 @@ This mitigates the cases where the service state is heavy and rebalance of one t
 A to B means huge amount of data transfer. Client that goes offline and online frequently, if using this settings
 avoid frequent and heavy rebalances.
 
-NOTE: It has to be unique across all the clients connected to same topic, in case another client connects
+NOTE: It has to be unique across all the clients belonging to the same <<plugins-{type}s-{plugin}-group_id>>, in case another client connects
 with same `group.instance.id` value then the oldest is kicked off.
 Generally could be something like a hostname, an IP or anything that uniquely identifies the client application.
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -349,21 +349,22 @@ is also recommended.
 ===== `group_instance_id`
 
 * Value type is <<string,string>>
-* Optional, there is no default value for this setting.
+* There is no default value for this setting.
 
-The static membership identifier for this consumer. Static membership feature was introduced in
+The static membership identifier for this Logstash Kafka consumer. Static membership feature was introduced in
 https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances[KIP-345],
-available under Kafka property `group.instance.id` and aims to avoid rebalances in contexts where a lot of data
-has to be handed off after a consumer goes offline.
-This mitigates the cases where the service state is heavy and rebalance of one topic partition from instance
-A to B means huge amount of data transfer. Client that goes offline and online frequently, if using this settings
-avoid frequent and heavy rebalances.
+available under Kafka property `group.instance.id`.
+Its purpose is to avoid rebalances in situations in which a lot of data
+has to be forwarded after a consumer goes offline.
+This feature mitigates cases where the service state is heavy and the rebalance of one topic partition from instance
+A to B would cause a huge amount of data to be transferred.
+A client that goes offline/online frequently can avoid frequent and heavy rebalances by using this option.
 
 NOTE: It has to be unique across all the clients belonging to the same <<plugins-{type}s-{plugin}-group_id>>, in case another client connects
 with same `group.instance.id` value then the oldest is kicked off.
-Generally could be something like a hostname, an IP or anything that uniquely identifies the client application.
+You can set this value to use information such as a hostname, an IP, or anything that uniquely identifies the client application.
 
-NOTE: In cases when multiple threads are configured, `consumer_threads` is greater than one, a suffix is appended to
+NOTE: In cases when multiple threads are configured and `consumer_threads` is greater than one, a suffix is appended to
 the `group_instance_id` to avoid collisions.
 
 [id="plugins-{type}s-{plugin}-heartbeat_interval_ms"]

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -48,6 +48,7 @@ build/kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 -
 build/kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic logstash_integration_lz4_topic --bootstrap-server localhost:9092
 build/kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic logstash_integration_zstd_topic --bootstrap-server localhost:9092
 build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_integration_partitioner_topic --bootstrap-server localhost:9092
+build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_integration_static_membership_topic --bootstrap-server localhost:9092
 curl -s -o build/apache_logs.txt https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_plain --broker-list localhost:9092
 cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_snappy --broker-list localhost:9092 --compression-codec snappy

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -414,7 +414,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       props.put(kafka::FETCH_MAX_WAIT_MS_CONFIG, fetch_max_wait_ms.to_s) unless fetch_max_wait_ms.nil?
       props.put(kafka::FETCH_MIN_BYTES_CONFIG, fetch_min_bytes.to_s) unless fetch_min_bytes.nil?
       props.put(kafka::GROUP_ID_CONFIG, group_id)
-      props.put(kafka::GROUP_INSTANCE_ID_CONFIG, group_instance_id)
+      if group_instance_id
+        # group_instance_id in case of nil can't be set
+        props.put(kafka::GROUP_INSTANCE_ID_CONFIG, group_instance_id)
+      end
       props.put(kafka::HEARTBEAT_INTERVAL_MS_CONFIG, heartbeat_interval_ms.to_s) unless heartbeat_interval_ms.nil?
       props.put(kafka::ISOLATION_LEVEL_CONFIG, isolation_level)
       props.put(kafka::KEY_DESERIALIZER_CLASS_CONFIG, key_deserializer_class)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -124,6 +124,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # that happens to be made up of multiple processors. Messages in a topic will be distributed to all
   # Logstash instances with the same `group_id`
   config :group_id, :validate => :string, :default => "logstash"
+  config :group_instance_id, :validate => :string
   # The expected time between heartbeats to the consumer coordinator. Heartbeats are used to ensure 
   # that the consumer's session stays active and to facilitate rebalancing when new
   # consumers join or leave the group. The value must be set lower than
@@ -335,6 +336,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     rescue org.apache.kafka.common.errors.WakeupException => e
       logger.debug("Wake up from poll", :kafka_error_message => e)
       raise e unless stop?
+    rescue org.apache.kafka.common.errors.FencedInstanceIdException => e
+      logger.error("Another consumer with same group.instance.id has connected")
+      raise e unless stop?
     rescue => e
       logger.error("Unable to poll Kafka consumer",
                    :kafka_error_message => e,
@@ -407,6 +411,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       props.put(kafka::FETCH_MAX_WAIT_MS_CONFIG, fetch_max_wait_ms.to_s) unless fetch_max_wait_ms.nil?
       props.put(kafka::FETCH_MIN_BYTES_CONFIG, fetch_min_bytes.to_s) unless fetch_min_bytes.nil?
       props.put(kafka::GROUP_ID_CONFIG, group_id)
+      props.put(kafka::GROUP_INSTANCE_ID_CONFIG, group_instance_id)
       props.put(kafka::HEARTBEAT_INTERVAL_MS_CONFIG, heartbeat_interval_ms.to_s) unless heartbeat_interval_ms.nil?
       props.put(kafka::ISOLATION_LEVEL_CONFIG, isolation_level)
       props.put(kafka::KEY_DESERIALIZER_CLASS_CONFIG, key_deserializer_class)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -136,7 +136,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # been aborted. Non-transactional messages will be returned unconditionally in either mode.
   config :isolation_level, :validate => ["read_uncommitted", "read_committed"], :default => "read_uncommitted" # Kafka default
   # Java Class used to deserialize the record's key
-  config :key_deserializer_class, :validate => :string, :default => "org.apache.kafka.common.serialization.StringDeserializer"
+  config :key_deserializer_class, :validate => :string, :default => DEFAULT_DESERIALIZER_CLASS
   # The maximum delay between invocations of poll() when using consumer group management. This places 
   # an upper bound on the amount of time that the consumer can be idle before fetching more records. 
   # If poll() is not called before expiration of this timeout, then the consumer is considered failed and 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -124,6 +124,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # that happens to be made up of multiple processors. Messages in a topic will be distributed to all
   # Logstash instances with the same `group_id`
   config :group_id, :validate => :string, :default => "logstash"
+  # Set a static group instance id used in static membership feature to avoid rebalancing when a
+  # consumer goes offline. If set and `consumer_threads` is greater than 1 then for each
+  # consumer crated by each thread an artificial suffix is appended to the user provided `group_instance_id`
+  # to avoid clashing.
   config :group_instance_id, :validate => :string
   # The expected time between heartbeats to the consumer coordinator. Heartbeats are used to ensure 
   # that the consumer's session stays active and to facilitate rebalancing when new

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -344,7 +344,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       logger.debug("Wake up from poll", :kafka_error_message => e)
       raise e unless stop?
     rescue org.apache.kafka.common.errors.FencedInstanceIdException => e
-      logger.error("Another consumer with same group.instance.id has connected")
+      logger.error("Another consumer with same group.instance.id has connected", :original_error_message => e.message)
       raise e unless stop?
     rescue => e
       logger.error("Unable to poll Kafka consumer",

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -289,7 +289,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   public
   def run(logstash_queue)
     @runner_consumers = consumer_threads.times.map do |i|
-      thread_group_instance_id = consumer_threads > 0 && group_instance_id ? "#{group_instance_id}-#{i}" : group_instance_id
+      thread_group_instance_id = consumer_threads > 1 && group_instance_id ? "#{group_instance_id}-#{i}" : group_instance_id
       subscribe(create_consumer("#{client_id}-#{i}", thread_group_instance_id))
     end
     @runner_threads = @runner_consumers.map.with_index { |consumer, i| thread_runner(logstash_queue, consumer,

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -418,10 +418,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       props.put(kafka::FETCH_MAX_WAIT_MS_CONFIG, fetch_max_wait_ms.to_s) unless fetch_max_wait_ms.nil?
       props.put(kafka::FETCH_MIN_BYTES_CONFIG, fetch_min_bytes.to_s) unless fetch_min_bytes.nil?
       props.put(kafka::GROUP_ID_CONFIG, group_id)
-      if group_instance_id
-        # group_instance_id in case of nil can't be set
-        props.put(kafka::GROUP_INSTANCE_ID_CONFIG, group_instance_id)
-      end
+      props.put(kafka::GROUP_INSTANCE_ID_CONFIG, group_instance_id) unless group_instance_id.nil?
       props.put(kafka::HEARTBEAT_INTERVAL_MS_CONFIG, heartbeat_interval_ms.to_s) unless heartbeat_interval_ms.nil?
       props.put(kafka::ISOLATION_LEVEL_CONFIG, isolation_level)
       props.put(kafka::KEY_DESERIALIZER_CLASS_CONFIG, key_deserializer_class)

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.0.0'
+  s.version         = '11.1.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -205,7 +205,7 @@ describe "inputs/kafka", :integration => true do
     end
 
     it "input plugin disconnects from the broker when another client with same static membership connects" do
-      queue = Queue.new
+      queue = java.util.concurrent.ArrayBlockingQueue.new(10)
       kafka_input = LogStash::Inputs::Kafka.new(consumer_config)
       kafka_input.register
 
@@ -229,7 +229,7 @@ describe "inputs/kafka", :integration => true do
       let(:multi_consumer_config) { consumer_config.merge({"consumer_threads" => 2}) }
 
       it "should avoid to connect with same 'group.instance.id'" do
-        queue = Queue.new
+        queue = java.util.concurrent.ArrayBlockingQueue.new(10)
         kafka_input = LogStash::Inputs::Kafka.new(multi_consumer_config)
         kafka_input.register
 
@@ -282,7 +282,8 @@ def wait_kafka_input_is_ready(topic, queue)
   send_message(record)
 
   # Wait the message is processed
-  message = queue.pop
+  message = queue.poll(1, java.util.concurrent.TimeUnit::MINUTES)
+  expect(message).to_not be(nil)
 end
 
 def consume_messages(config, queue: Queue.new, timeout:, event_count:)

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -283,7 +283,7 @@ def wait_kafka_input_is_ready(topic, queue)
 
   # Wait the message is processed
   message = queue.poll(1, java.util.concurrent.TimeUnit::MINUTES)
-  expect(message).to_not be(nil)
+  expect(message).to_not eq(nil)
 end
 
 def consume_messages(config, queue: Queue.new, timeout:, event_count:)

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -214,7 +214,7 @@ def create_consumer_and_start_consuming(static_group_id)
   Thread.new do
     LogStash::Util::set_thread_name("integration_test_simple_consumer")
     begin
-      consumer.subscribe(["logstash_integration_topic_plain"])
+      consumer.subscribe(["logstash_integration_static_membership_topic"])
       records = consumer.poll(java.time.Duration.ofSeconds(3))
       "saboteur exited"
     rescue => e
@@ -228,7 +228,7 @@ end
 describe "Kafka static membership 'group.instance.id' setting", :integration => true do
   let(:consumer_config) do
     {
-      "topics" => ["logstash_integration_topic_plain"],
+      "topics" => ["logstash_integration_static_membership_topic"],
       "group_id" => "logstash",
       "consumer_threads" => 1,
       "group_instance_id" => "test_static_group_id"
@@ -253,7 +253,7 @@ describe "Kafka static membership 'group.instance.id' setting", :integration => 
     input_worker = java.lang.Thread.new { kafka_input.run(queue) }
     begin
       input_worker.start
-      wait_kafka_input_is_ready("logstash_integration_topic_plain", queue)
+      wait_kafka_input_is_ready("logstash_integration_static_membership_topic", queue)
       saboteur_kafka_consumer = create_consumer_and_start_consuming("test_static_group_id")
       saboteur_kafka_consumer.run # ask to be scheduled
       saboteur_kafka_consumer.join
@@ -277,7 +277,7 @@ describe "Kafka static membership 'group.instance.id' setting", :integration => 
       input_worker = java.lang.Thread.new { kafka_input.run(queue) }
       begin
         input_worker.start
-        wait_kafka_input_is_ready("logstash_integration_topic_plain", queue)
+        wait_kafka_input_is_ready("logstash_integration_static_membership_topic", queue)
       ensure
         kafka_input.stop
         input_worker.join(1_000)

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -212,7 +212,7 @@ describe "inputs/kafka", :integration => true do
     end
 
     it "input plugin disconnects from the broker when another client with same static membership connects" do
-      expect(logger).to receive(:error).with("Another consumer with same group.instance.id has connected")
+      expect(logger).to receive(:error).with("Another consumer with same group.instance.id has connected", anything)
 
       input_worker = java.lang.Thread.new { kafka_input.run(queue) }
       begin
@@ -232,7 +232,7 @@ describe "inputs/kafka", :integration => true do
       let(:consumer_config) { base_config.merge({"consumer_threads" => 2}) }
 
       it "should avoid to connect with same 'group.instance.id'" do
-        expect(logger).to_not receive(:error).with("Another consumer with same group.instance.id has connected")
+        expect(logger).to_not receive(:error).with("Another consumer with same group.instance.id has connected", anything)
 
         input_worker = java.lang.Thread.new { kafka_input.run(queue) }
         begin

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -225,7 +225,7 @@ def create_consumer_and_start_consuming(static_group_id)
   end
 end
 
-describe "Kafka static membership 'group.instance.id' setting" do
+describe "Kafka static membership 'group.instance.id' setting", :integration => true do
   let(:consumer_config) do
     {
       "topics" => ["logstash_integration_topic_plain"],

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -193,6 +193,8 @@ describe "inputs/kafka", :integration => true do
         "topics" => ["logstash_integration_static_membership_topic"],
         "group_id" => "logstash",
         "consumer_threads" => 1,
+        # this is needed because the worker thread could be executed little after the producer sent the "up" message
+        "auto_offset_reset" => "earliest",
         "group_instance_id" => "test_static_group_id"
       }
     end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -243,7 +243,7 @@ describe "Kafka static membership 'group.instance.id' setting", :integration => 
     end
   end
 
-  it "input plugin is terminated if second client connect with same 'group.instance.id'" do
+  it "input plugin disconnects from the broker when another client with same static membership connects" do
     queue = Queue.new
     kafka_input = LogStash::Inputs::Kafka.new(consumer_config)
     kafka_input.register
@@ -264,10 +264,10 @@ describe "Kafka static membership 'group.instance.id' setting", :integration => 
     end
   end
 
-  context "when multiple consumer threads are configured" do
+  context "when the plugin is configured with multiple consumer threads" do
     let(:multi_consumer_config) { consumer_config.merge({"consumer_threads" => 2}) }
 
-    it "the plugin should work as expected" do
+    it "should avoid to connect with same 'group.instance.id'" do
       queue = Queue.new
       kafka_input = LogStash::Inputs::Kafka.new(multi_consumer_config)
       kafka_input.register

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -79,6 +79,7 @@ describe "inputs/kafka", :integration => true do
     producer = org.apache.kafka.clients.producer.KafkaProducer.new(props)
 
     producer.send(record)
+    producer.flush
     producer.close
   end
 

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -297,7 +297,7 @@ describe LogStash::Inputs::Kafka do
           to receive(:new).with(hash_including('client.rack' => 'EU-R1')).
               and_return kafka_client = double('kafka-consumer')
 
-      expect( subject.send(:create_consumer, 'sample_client-0') ).to be kafka_client
+      expect( subject.send(:create_consumer, 'sample_client-0', 'group_instance_id') ).to be kafka_client
     end
   end
 
@@ -309,7 +309,7 @@ describe LogStash::Inputs::Kafka do
           to receive(:new).with(hash_including('session.timeout.ms' => '25000', 'max.poll.interval.ms' => '345000')).
               and_return kafka_client = double('kafka-consumer')
 
-      expect( subject.send(:create_consumer, 'sample_client-1') ).to be kafka_client
+      expect( subject.send(:create_consumer, 'sample_client-1', 'group_instance_id') ).to be kafka_client
     end
   end
 
@@ -321,7 +321,7 @@ describe LogStash::Inputs::Kafka do
           to receive(:new).with(hash_including('session.timeout.ms' => '25200', 'max.poll.interval.ms' => '123000')).
               and_return kafka_client = double('kafka-consumer')
 
-      expect( subject.send(:create_consumer, 'sample_client-2') ).to be kafka_client
+      expect( subject.send(:create_consumer, 'sample_client-2', 'group_instance_id') ).to be kafka_client
     end
   end
 
@@ -333,7 +333,7 @@ describe LogStash::Inputs::Kafka do
           to receive(:new).with(hash_including('enable.auto.commit' => 'false', 'check.crcs' => 'true')).
               and_return kafka_client = double('kafka-consumer')
 
-      expect( subject.send(:create_consumer, 'sample_client-3') ).to be kafka_client
+      expect( subject.send(:create_consumer, 'sample_client-3', 'group_instance_id') ).to be kafka_client
       expect( subject.enable_auto_commit ).to be false
     end
   end
@@ -346,7 +346,7 @@ describe LogStash::Inputs::Kafka do
           to receive(:new).with(hash_including('enable.auto.commit' => 'true', 'check.crcs' => 'false')).
               and_return kafka_client = double('kafka-consumer')
 
-      expect( subject.send(:create_consumer, 'sample_client-4') ).to be kafka_client
+      expect( subject.send(:create_consumer, 'sample_client-4', 'group_instance_id') ).to be kafka_client
       expect( subject.enable_auto_commit ).to be true
     end
   end


### PR DESCRIPTION
## Release notes

Added config `group_instance_id` to use the Kafka's consumer static membership feature


## What does this PR do?

Static membership is reflected in the Kafka property `group.instance.id`, which has to be a unique identifier of the consumer instance provided by end user.
If `consumer_threads` settings is 1 the value is passed directly down to the Kafka's consumer configuration, but if threads count is more than 1, as per [KIP-345](https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances) it would clash, so in that case, a postfix `-<thread-index>` is added.

## Why is it important/What is the impact to the user?

The [static membership](https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances) feature offered by Kafka client's consumer is intended to bind a consumer to a partition, this is needed in cases where the cost of state replication between consumers during a rebalance, is high. This PR exposes the feature, which is optional, to Logstash's users.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] test locally on rel Kafka with 1 thread and more threads
- [x] test locally with another client that kicks off the Kafka input plugin
- [x] obtain a  docs review.

## How to test this PR locally

### Runs a local Kafka cluster
Fro the clone of this repository launch the test Kafka script
```bash
./kafka_test_setup.sh
```

### Connect a producer
- start the producer with
```bash
bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic "logstash_integration_static_membership_topic"
```

### Setup Logstash Kafka input & run 
- Adds the plugin definition in `Gemfile`
```
gem "logstash-integration-kafka", :path => "/path/to/logstash_plugins/logstash-integration-kafka"
```
- Install the plugin in development mode
```bash
bin/logstash-plugin install --no-verify
```
- edit the pipeline `test_pipeline.conf` file
```
input {
  kafka {
    bootstrap_servers => ["localhost:9092"]
    topics => ["logstash_integration_static_membership_topic"]
    group_id => "logstash"
    consumer_threads => 1

    group_instance_id => "test_static_group_id"
  }
}


output {
  stdout {
    codec => rubydebug
  }
}
```

### Verify Logstash is receiving data
From the producer's console send some data and verify on the Logstash console the message is received.

### Verify another consumer kicks off Logstash
Start another consumer with same `group.instance.id` in same consumer group
- In the folder `build/kafka the file `client_config.properties` with content
```
group.instance.id=test_static_group_id
```
```bash
bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic "logstash_integration_static_membership_topic" --from-beginning --group logstash --consumer.config "${PWD}/client_config.properties"
```

### Test with multiple threads
- Edit the pipeline to have `consumer_threads` > 1 and verify that another consumer doesn't kicks off because the `group.instance.id` has now been suffixed with `-n` for each Logstash Kafka consumer threads.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #134

## Use cases

As a Kafka uses that want to avoid that consumers spend a lot of time during rebalances, specially when they have heavy state, I want to be able to assign a "static membership" id to every consumer.

