### PR TITLE
Adds schema registry's truststore and keystore settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .idea/
 vendor
 *.jar
+tls_repository/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2.0
+ - Added TLS truststore and keystore settings specifically to access the schema registry [#137](https://github.com/logstash-plugins/logstash-integration-kafka/pull/137)
+
 ## 11.1.0
  - Added config `group_instance_id` to use the Kafka's consumer static membership feature [#135](https://github.com/logstash-plugins/logstash-integration-kafka/pull/135)
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -135,10 +135,10 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-schema_registry_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_secret>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_path>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
-| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_path>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
 | <<plugins-{type}s-{plugin}-schema_registry_url>> |<<uri,uri>>|No
@@ -604,8 +604,8 @@ Set the address of a forward HTTP proxy. An empty string is treated as if proxy 
 
 Set the password for basic authorization to access remote Schema Registry.
 
-[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location"]
-===== `schema_registry_ssl_keystore_location`
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_path"]
+===== `schema_registry_ssl_keystore_path`
 
 * Value type is <<path,path>>
 * There is no default value for this setting.
@@ -628,8 +628,8 @@ If schema registry authentication is required, this setting stores the keystore 
 
 The format of the keystore file. It must be either `jks` or `PKCS12`.
 
-[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location"]
-===== `schema_registry_ssl_truststore_location`
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_path"]
+===== `schema_registry_ssl_truststore_path`
 
 * Value type is <<path,path>>
 * There is no default value for this setting.

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -135,6 +135,12 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-schema_registry_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_secret>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
 | <<plugins-{type}s-{plugin}-schema_registry_url>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_validation>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
@@ -597,6 +603,54 @@ Set the address of a forward HTTP proxy. An empty string is treated as if proxy 
 * There is no default value for this setting.
 
 Set the password for basic authorization to access remote Schema Registry.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location"]
+===== `schema_registry_ssl_keystore_location`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+If schema registry client authentication is required, this setting stores the keystore path.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_password"]
+===== `schema_registry_ssl_keystore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+If schema registry authentication is required, this setting stores the keystore password.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_type"]
+===== `schema_registry_ssl_keystore_type`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The format of the keystore file. It must be either `jks` or `PKCS12`.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location"]
+===== `schema_registry_ssl_truststore_location`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+The truststore path to validate the schema registry's certificate.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_password"]
+===== `schema_registry_ssl_truststore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+The schema registry truststore password.
+
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_type"]
+===== `schema_registry_ssl_truststore_type`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The format of the schema registry's truststore file. It must be either `jks` or `PKCS12`.
 
 [id="plugins-{type}s-{plugin}-schema_registry_url"]
 ===== `schema_registry_url`

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -135,10 +135,10 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-schema_registry_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_secret>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_path>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_keystore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
-| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_path>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-schema_registry_ssl_truststore_type>> |<<string,string>>, one of `["jks", "PKCS12"]`|No
 | <<plugins-{type}s-{plugin}-schema_registry_url>> |<<uri,uri>>|No
@@ -604,8 +604,8 @@ Set the address of a forward HTTP proxy. An empty string is treated as if proxy 
 
 Set the password for basic authorization to access remote Schema Registry.
 
-[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_path"]
-===== `schema_registry_ssl_keystore_path`
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_keystore_location"]
+===== `schema_registry_ssl_keystore_location`
 
 * Value type is <<path,path>>
 * There is no default value for this setting.
@@ -628,8 +628,8 @@ If schema registry authentication is required, this setting stores the keystore 
 
 The format of the keystore file. It must be either `jks` or `PKCS12`.
 
-[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_path"]
-===== `schema_registry_ssl_truststore_path`
+[id="plugins-{type}s-{plugin}-schema_registry_ssl_truststore_location"]
+===== `schema_registry_ssl_truststore_location`
 
 * Value type is <<path,path>>
 * There is no default value for this setting.

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -32,7 +32,6 @@ echo "Setup Confluent Platform"
 if [ ! -e confluent-community-5.5.1-2.12.tar.gz ]; then
   echo "Confluent Platform not present locally, downloading"
   curl -s -o confluent-community-5.5.1-2.12.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
-#curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
 fi
 cp confluent-community-5.5.1-2.12.tar.gz build/confluent_platform.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -27,6 +27,17 @@ sleep 10
 echo "Downloading Confluent Platform"
 curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
+
+echo "Configuring TLS on Schema registry"
+rm -Rf tls_repository
+mkdir tls_repository
+./setup_keystore_and_truststore.sh
+# configure schema-registry to handle https on 8083 port
+sed -i 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' build/confluent_platform/etc/schema-registry/schema-registry.properties
+echo "ssl.keystore.location=`pwd`/tls_repository/schema_reg.jks" >> build/confluent_platform/etc/schema-registry/schema-registry.properties
+echo "ssl.keystore.password=changeit" >> build/confluent_platform/etc/schema-registry/schema-registry.properties
+echo "ssl.key.password=changeit" >> build/confluent_platform/etc/schema-registry/schema-registry.properties
+
 cp build/confluent_platform/etc/schema-registry/schema-registry.properties build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.method=BASIC" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties
 echo "authentication.roles=admin,developer,user,sr-user" >> build/confluent_platform/etc/schema-registry/authed-schema-registry.properties

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -2,6 +2,7 @@
 # Setup Kafka and create test topics
 
 set -ex
+# check if KAFKA_VERSION env var is set
 if [ -n "${KAFKA_VERSION+1}" ]; then
   echo "KAFKA_VERSION is $KAFKA_VERSION"
 else
@@ -29,11 +30,19 @@ build/kafka/bin/kafka-server-start.sh -daemon build/kafka/config/server.properti
 sleep 10
 
 echo "Setup Confluent Platform"
-if [ ! -e confluent-community-5.5.1-2.12.tar.gz ]; then
-  echo "Confluent Platform not present locally, downloading"
-  curl -s -o confluent-community-5.5.1-2.12.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
+# check if CONFLUENT_VERSION env var is set
+if [ -n "${CONFLUENT_VERSION+1}" ]; then
+  echo "CONFLUENT_VERSION is $CONFLUENT_VERSION"
+else
+   CONFLUENT_VERSION=5.5.1
 fi
-cp confluent-community-5.5.1-2.12.tar.gz build/confluent_platform.tar.gz
+if [ ! -e confluent-community-$CONFLUENT_VERSION-2.12.tar.gz ]; then
+  echo "Confluent Platform not present locally, downloading"
+  CONFLUENT_MINOR=$(echo "$CONFLUENT_VERSION" | sed -n 's/^\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p')
+  echo "CONFLUENT_MINOR is $CONFLUENT_MINOR"
+  curl -s -o confluent-community-$CONFLUENT_VERSION-2.12.tar.gz http://packages.confluent.io/archive/$CONFLUENT_MINOR/confluent-community-$CONFLUENT_VERSION-2.12.tar.gz
+fi
+cp confluent-community-$CONFLUENT_VERSION-2.12.tar.gz build/confluent_platform.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
 
 echo "Configuring TLS on Schema registry"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -41,7 +41,11 @@ rm -Rf tls_repository
 mkdir tls_repository
 ./setup_keystore_and_truststore.sh
 # configure schema-registry to handle https on 8083 port
-sed -i 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' build/confluent_platform/etc/schema-registry/schema-registry.properties
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' build/confluent_platform/etc/schema-registry/schema-registry.properties
+else
+  sed -i 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' build/confluent_platform/etc/schema-registry/schema-registry.properties
+fi
 echo "ssl.keystore.location=`pwd`/tls_repository/schema_reg.jks" >> build/confluent_platform/etc/schema-registry/schema-registry.properties
 echo "ssl.keystore.password=changeit" >> build/confluent_platform/etc/schema-registry/schema-registry.properties
 echo "ssl.key.password=changeit" >> build/confluent_platform/etc/schema-registry/schema-registry.properties

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -13,8 +13,12 @@ export _JAVA_OPTIONS="-Djava.net.preferIPv4Stack=true"
 rm -rf build
 mkdir build
 
-echo "Downloading Kafka version $KAFKA_VERSION"
-curl -s -o build/kafka.tgz "https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
+echo "Setup Kafka version $KAFKA_VERSION"
+if [ ! -e "kafka_2.12-$KAFKA_VERSION.tgz" ]; then
+  echo "Kafka not present locally, downloading"
+  curl -s -o "kafka_2.12-$KAFKA_VERSION.tgz" "https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
+fi
+cp kafka_2.12-$KAFKA_VERSION.tgz build/kafka.tgz
 mkdir build/kafka && tar xzf build/kafka.tgz -C build/kafka --strip-components 1
 
 echo "Starting ZooKeeper"
@@ -24,8 +28,13 @@ echo "Starting Kafka broker"
 build/kafka/bin/kafka-server-start.sh -daemon build/kafka/config/server.properties --override advertised.host.name=127.0.0.1 --override log.dirs="${PWD}/build/kafka-logs"
 sleep 10
 
-echo "Downloading Confluent Platform"
-curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
+echo "Setup Confluent Platform"
+if [ ! -e confluent-community-5.5.1-2.12.tar.gz ]; then
+  echo "Confluent Platform not present locally, downloading"
+  curl -s -o confluent-community-5.5.1-2.12.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
+#curl -s -o build/confluent_platform.tar.gz http://packages.confluent.io/archive/5.5/confluent-community-5.5.1-2.12.tar.gz
+fi
+cp confluent-community-5.5.1-2.12.tar.gz build/confluent_platform.tar.gz
 mkdir build/confluent_platform && tar xzf build/confluent_platform.tar.gz -C build/confluent_platform --strip-components 1
 
 echo "Configuring TLS on Schema registry"

--- a/kafka_test_teardown.sh
+++ b/kafka_test_teardown.sh
@@ -10,3 +10,6 @@ echo "Stopping Kafka broker"
 build/kafka/bin/kafka-server-stop.sh
 echo "Stopping zookeeper"
 build/kafka/bin/zookeeper-server-stop.sh
+
+echo "Clean TLS folder"
+rm -Rf tls_repository

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -460,14 +460,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         set_trustore_keystore_config(props)
         set_sasl_config(props)
       end
-      if schema_registry_ssl_truststore_location
-        props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_location)
+      if schema_registry_ssl_truststore_path
+        props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_path)
         props.put('schema.registry.ssl.truststore.password', schema_registry_ssl_truststore_password.value)
         props.put('schema.registry.ssl.truststore.type', schema_registry_ssl_truststore_type)
       end
 
-      if schema_registry_ssl_keystore_location
-        props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_location)
+      if schema_registry_ssl_keystore_path
+        props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_path)
         props.put('schema.registry.ssl.keystore.password', schema_registry_ssl_keystore_password.value)
         props.put('schema.registry.ssl.keystore.type', schema_registry_ssl_keystore_type)
       end

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -460,14 +460,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         set_trustore_keystore_config(props)
         set_sasl_config(props)
       end
-      if schema_registry_ssl_truststore_path
-        props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_path)
+      if schema_registry_ssl_truststore_location
+        props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_location)
         props.put('schema.registry.ssl.truststore.password', schema_registry_ssl_truststore_password.value)
         props.put('schema.registry.ssl.truststore.type', schema_registry_ssl_truststore_type)
       end
 
-      if schema_registry_ssl_keystore_path
-        props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_path)
+      if schema_registry_ssl_keystore_location
+        props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_location)
         props.put('schema.registry.ssl.keystore.password', schema_registry_ssl_keystore_password.value)
         props.put('schema.registry.ssl.keystore.type', schema_registry_ssl_keystore_type)
       end

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -460,6 +460,15 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         set_trustore_keystore_config(props)
         set_sasl_config(props)
       end
+      if schema_registry_ssl_truststore_location
+        props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_location)
+        props.put('schema.registry.ssl.truststore.password', schema_registry_ssl_truststore_password.value)
+      end
+
+      if schema_registry_ssl_keystore_location
+        props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_location)
+        props.put('schema.registry.ssl.keystore.password', schema_registry_ssl_keystore_password.value)
+      end
 
       org.apache.kafka.clients.consumer.KafkaConsumer.new(props)
     rescue => e

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -463,11 +463,13 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       if schema_registry_ssl_truststore_location
         props.put('schema.registry.ssl.truststore.location', schema_registry_ssl_truststore_location)
         props.put('schema.registry.ssl.truststore.password', schema_registry_ssl_truststore_password.value)
+        props.put('schema.registry.ssl.truststore.type', schema_registry_ssl_truststore_type)
       end
 
       if schema_registry_ssl_keystore_location
         props.put('schema.registry.ssl.keystore.location', schema_registry_ssl_keystore_location)
         props.put('schema.registry.ssl.keystore.password', schema_registry_ssl_keystore_password.value)
+        props.put('schema.registry.ssl.keystore.type', schema_registry_ssl_keystore_type)
       end
 
       org.apache.kafka.clients.consumer.KafkaConsumer.new(props)

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -31,7 +31,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_keystore_password, :validate => :password
 
       # The keystore type
-      config :schema_registry_ssl_keystore_type, :validate => :string, :default => "jks"
+      config :schema_registry_ssl_keystore_type, :validate => ['jks', 'PKCS12'], :default => "jks"
 
       # The JKS truststore path to validate the Schema Registry's certificate.
       config :schema_registry_ssl_truststore_path, :validate => :string
@@ -40,7 +40,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_truststore_password, :validate => :password
 
       # The truststore type
-      config :schema_registry_ssl_truststore_type, :validate => :string, :default => "jks"
+      config :schema_registry_ssl_truststore_type, :validate => ['jks', 'PKCS12'], :default => "jks"
 
       # Option to skip validating the schema registry during registration. This can be useful when using
       # certificate based auth

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -25,7 +25,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_proxy, :validate => :uri
 
       # If schema registry client authentication is required, this setting stores the keystore path.
-      config :schema_registry_ssl_keystore_path, :validate => :string
+      config :schema_registry_ssl_keystore_location, :validate => :string
 
       # The keystore password.
       config :schema_registry_ssl_keystore_password, :validate => :password
@@ -34,7 +34,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_keystore_type, :validate => ['jks', 'PKCS12'], :default => "jks"
 
       # The JKS truststore path to validate the Schema Registry's certificate.
-      config :schema_registry_ssl_truststore_path, :validate => :string
+      config :schema_registry_ssl_truststore_location, :validate => :string
 
       # The truststore password.
       config :schema_registry_ssl_truststore_password, :validate => :password
@@ -86,15 +86,15 @@ module LogStash module PluginMixins module Kafka
       if schema_registry_key and !schema_registry_key.empty?
         options[:auth] = {:user => schema_registry_key, :password => schema_registry_secret.value}
       end
-      if schema_registry_ssl_truststore_path and !schema_registry_ssl_truststore_path.empty?
+      if schema_registry_ssl_truststore_location and !schema_registry_ssl_truststore_location.empty?
         options[:ssl] = {} unless options.key?(:ssl)
-        options[:ssl][:truststore] = schema_registry_ssl_truststore_path unless schema_registry_ssl_truststore_path.nil?
+        options[:ssl][:truststore] = schema_registry_ssl_truststore_location unless schema_registry_ssl_truststore_location.nil?
         options[:ssl][:truststore_password] = schema_registry_ssl_truststore_password.value unless schema_registry_ssl_truststore_password.nil?
         options[:ssl][:truststore_type] = schema_registry_ssl_truststore_type unless schema_registry_ssl_truststore_type.nil?
       end
-      if schema_registry_ssl_keystore_path and !schema_registry_ssl_keystore_path.empty?
+      if schema_registry_ssl_keystore_location and !schema_registry_ssl_keystore_location.empty?
         options[:ssl] = {} unless options.key? :ssl
-        options[:ssl][:keystore] = schema_registry_ssl_keystore_path unless schema_registry_ssl_keystore_path.nil?
+        options[:ssl][:keystore] = schema_registry_ssl_keystore_location unless schema_registry_ssl_keystore_location.nil?
         options[:ssl][:keystore_password] = schema_registry_ssl_keystore_password.value unless schema_registry_ssl_keystore_password.nil?
         options[:ssl][:keystore_type] = schema_registry_ssl_keystore_type unless schema_registry_ssl_keystore_type.nil?
       end

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -88,19 +88,15 @@ module LogStash module PluginMixins module Kafka
       end
       if schema_registry_ssl_truststore_path and !schema_registry_ssl_truststore_path.empty?
         options[:ssl] = {} unless options.key?(:ssl)
-        options[:ssl].merge!({
-          :truststore => schema_registry_ssl_truststore_path,
-          :truststore_password => schema_registry_ssl_truststore_password.value,
-          :truststore_type => schema_registry_ssl_truststore_type,
-        })
+        options[:ssl][:truststore] = schema_registry_ssl_truststore_path unless schema_registry_ssl_truststore_path.nil?
+        options[:ssl][:truststore_password] = schema_registry_ssl_truststore_password.value unless schema_registry_ssl_truststore_password.nil?
+        options[:ssl][:truststore_type] = schema_registry_ssl_truststore_type unless schema_registry_ssl_truststore_type.nil?
       end
       if schema_registry_ssl_keystore_path and !schema_registry_ssl_keystore_path.empty?
         options[:ssl] = {} unless options.key? :ssl
-        options[:ssl].merge!({
-          :keystore => schema_registry_ssl_keystore_path,
-          :keystore_password => schema_registry_ssl_keystore_password.value,
-          :keystore_type => schema_registry_ssl_keystore_type,
-        })
+        options[:ssl][:keystore] = schema_registry_ssl_keystore_path unless schema_registry_ssl_keystore_path.nil?
+        options[:ssl][:keystore_password] = schema_registry_ssl_keystore_password.value unless schema_registry_ssl_keystore_password.nil?
+        options[:ssl][:keystore_type] = schema_registry_ssl_keystore_type unless schema_registry_ssl_keystore_type.nil?
       end
 
       client = Manticore::Client.new(options)

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -28,10 +28,23 @@ module LogStash module PluginMixins module Kafka
       # certificate based auth
       config :schema_registry_validation, :validate => ['auto', 'skip'], :default => 'auto'
 
+      # If schema registry client authentication is required, this setting stores the keystore path.
       config :schema_registry_ssl_keystore_location, :validate => :string
+
+      # The keystore password.
       config :schema_registry_ssl_keystore_password, :validate => :password
+
+      # The keystore type
+      config :schema_registry_ssl_keystore_type, :validate => :string, :default => "JKS"
+
+      # The JKS truststore path to validate the Kafka broker's certificate.
       config :schema_registry_ssl_truststore_location, :validate => :string
+
+      # The truststore password.
       config :schema_registry_ssl_truststore_password, :validate => :password
+
+      # The truststore type
+      config :schema_registry_ssl_truststore_type, :validate => :string, :default => "JKS"
     end
 
     def check_schema_registry_parameters
@@ -77,14 +90,16 @@ module LogStash module PluginMixins module Kafka
         options[:ssl] = {} unless options.key?(:ssl)
         options[:ssl].merge!({
           :truststore => schema_registry_ssl_truststore_location,
-          :truststore_password => schema_registry_ssl_truststore_password.value
+          :truststore_password => schema_registry_ssl_truststore_password.value,
+          :truststore_type => schema_registry_ssl_truststore_type,
         })
       end
       if schema_registry_ssl_keystore_location and !schema_registry_ssl_keystore_location.empty?
         options[:ssl] = {} unless options.key? :ssl
         options[:ssl].merge!({
           :keystore => schema_registry_ssl_keystore_location,
-          :keystore_password => schema_registry_ssl_keystore_password.value
+          :keystore_password => schema_registry_ssl_keystore_password.value,
+          :keystore_type => schema_registry_ssl_keystore_type,
         })
       end
 

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -25,7 +25,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_proxy, :validate => :uri
 
       # If schema registry client authentication is required, this setting stores the keystore path.
-      config :schema_registry_ssl_keystore_location, :validate => :string
+      config :schema_registry_ssl_keystore_path, :validate => :string
 
       # The keystore password.
       config :schema_registry_ssl_keystore_password, :validate => :password
@@ -34,7 +34,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_keystore_type, :validate => :string, :default => "JKS"
 
       # The JKS truststore path to validate the Schema Registry's certificate.
-      config :schema_registry_ssl_truststore_location, :validate => :string
+      config :schema_registry_ssl_truststore_path, :validate => :string
 
       # The truststore password.
       config :schema_registry_ssl_truststore_password, :validate => :password
@@ -86,18 +86,18 @@ module LogStash module PluginMixins module Kafka
       if schema_registry_key and !schema_registry_key.empty?
         options[:auth] = {:user => schema_registry_key, :password => schema_registry_secret.value}
       end
-      if schema_registry_ssl_truststore_location and !schema_registry_ssl_truststore_location.empty?
+      if schema_registry_ssl_truststore_path and !schema_registry_ssl_truststore_path.empty?
         options[:ssl] = {} unless options.key?(:ssl)
         options[:ssl].merge!({
-          :truststore => schema_registry_ssl_truststore_location,
+          :truststore => schema_registry_ssl_truststore_path,
           :truststore_password => schema_registry_ssl_truststore_password.value,
           :truststore_type => schema_registry_ssl_truststore_type,
         })
       end
-      if schema_registry_ssl_keystore_location and !schema_registry_ssl_keystore_location.empty?
+      if schema_registry_ssl_keystore_path and !schema_registry_ssl_keystore_path.empty?
         options[:ssl] = {} unless options.key? :ssl
         options[:ssl].merge!({
-          :keystore => schema_registry_ssl_keystore_location,
+          :keystore => schema_registry_ssl_keystore_path,
           :keystore_password => schema_registry_ssl_keystore_password.value,
           :keystore_type => schema_registry_ssl_keystore_type,
         })

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -31,7 +31,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_keystore_password, :validate => :password
 
       # The keystore type
-      config :schema_registry_ssl_keystore_type, :validate => :string, :default => "JKS"
+      config :schema_registry_ssl_keystore_type, :validate => :string, :default => "jks"
 
       # The JKS truststore path to validate the Schema Registry's certificate.
       config :schema_registry_ssl_truststore_path, :validate => :string
@@ -40,7 +40,7 @@ module LogStash module PluginMixins module Kafka
       config :schema_registry_ssl_truststore_password, :validate => :password
 
       # The truststore type
-      config :schema_registry_ssl_truststore_type, :validate => :string, :default => "JKS"
+      config :schema_registry_ssl_truststore_type, :validate => :string, :default => "jks"
 
       # Option to skip validating the schema registry during registration. This can be useful when using
       # certificate based auth

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -24,10 +24,6 @@ module LogStash module PluginMixins module Kafka
       # This option permits to define a proxy to be used to reach the schema registry service instance.
       config :schema_registry_proxy, :validate => :uri
 
-      # Option to skip validating the schema registry during registration. This can be useful when using
-      # certificate based auth
-      config :schema_registry_validation, :validate => ['auto', 'skip'], :default => 'auto'
-
       # If schema registry client authentication is required, this setting stores the keystore path.
       config :schema_registry_ssl_keystore_location, :validate => :string
 
@@ -37,7 +33,7 @@ module LogStash module PluginMixins module Kafka
       # The keystore type
       config :schema_registry_ssl_keystore_type, :validate => :string, :default => "JKS"
 
-      # The JKS truststore path to validate the Kafka broker's certificate.
+      # The JKS truststore path to validate the Schema Registry's certificate.
       config :schema_registry_ssl_truststore_location, :validate => :string
 
       # The truststore password.
@@ -45,6 +41,10 @@ module LogStash module PluginMixins module Kafka
 
       # The truststore type
       config :schema_registry_ssl_truststore_type, :validate => :string, :default => "JKS"
+
+      # Option to skip validating the schema registry during registration. This can be useful when using
+      # certificate based auth
+      config :schema_registry_validation, :validate => ['auto', 'skip'], :default => 'auto'
     end
 
     def check_schema_registry_parameters

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.1.0'
+  s.version         = '11.2.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/setup_keystore_and_truststore.sh
+++ b/setup_keystore_and_truststore.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Setup Schema Registry keystore and Kafka's schema registry client's truststore
+set -ex
+
+echo "Generating schema registry key store"
+keytool -genkey -alias schema_reg -keyalg RSA -keystore tls_repository/schema_reg.jks -keypass changeit -storepass changeit  -validity 365  -keysize 2048 -dname "CN=localhost, OU=John Doe, O=Acme Inc, L=Unknown, ST=Unknown, C=IT"
+
+echo "Exporting schema registry certificate"
+keytool -exportcert -rfc -keystore tls_repository/schema_reg.jks -storepass changeit -alias schema_reg -file tls_repository/schema_reg_certificate.pem
+
+echo "Creating client's truststore and importing schema registry's certificate"
+keytool -import -trustcacerts -file tls_repository/schema_reg_certificate.pem -keypass changeit -storepass changeit -keystore tls_repository/clienttruststore.jks -noprompt

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -557,7 +557,7 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:subject_url) { "#{proto}://localhost:#{port}/subjects" }
     let(:plain_config)  { base_config.merge!({
       'schema_registry_url' => "#{proto}://localhost:#{port}",
-      'schema_registry_ssl_truststore_location' => File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+      'schema_registry_ssl_truststore_path' => File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
       'schema_registry_ssl_truststore_password' => 'changeit',
     }) }
 
@@ -585,7 +585,7 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:tls_base_config) do
       if tls
         base_config.merge({
-          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+          'schema_registry_ssl_truststore_path' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
           'schema_registry_ssl_truststore_password' => 'changeit',
         })
       else

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -557,7 +557,7 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:subject_url) { "#{proto}://localhost:#{port}/subjects" }
     let(:plain_config)  { base_config.merge!({
       'schema_registry_url' => "#{proto}://localhost:#{port}",
-      'schema_registry_ssl_truststore_path' => File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+      'schema_registry_ssl_truststore_location' => File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
       'schema_registry_ssl_truststore_password' => 'changeit',
     }) }
 
@@ -585,7 +585,7 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:tls_base_config) do
       if tls
         base_config.merge({
-          'schema_registry_ssl_truststore_path' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
           'schema_registry_ssl_truststore_password' => 'changeit',
         })
       else

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -582,15 +582,23 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:password) { "changeme" }
     let(:avro_topic_name) { "topic_avro_auth" }
     let(:subject_url) { "#{proto}://#{user}:#{password}@localhost:#{port}/subjects" }
+    let(:tls_base_config) do
+      if tls
+        base_config.merge({
+          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+          'schema_registry_ssl_truststore_password' => 'changeit',
+        })
+      else
+        base_config
+      end
+    end
 
     context 'using schema_registry_key' do
       let(:plain_config) do
-        base_config.merge!({
+        tls_base_config.merge!({
           'schema_registry_url' => "#{proto}://localhost:#{port}",
           'schema_registry_key' => user,
           'schema_registry_secret' => password,
-          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
-          'schema_registry_ssl_truststore_password' => 'changeit',
         })
       end
 
@@ -599,10 +607,8 @@ describe "Deserializing with the schema registry", :integration => true do
 
     context 'using schema_registry_url' do
       let(:plain_config) do
-        base_config.merge!({
+        tls_base_config.merge!({
           'schema_registry_url' => "#{proto}://#{user}:#{password}@localhost:#{port}",
-          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
-          'schema_registry_ssl_truststore_password' => 'changeit',
         })
       end
 

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -555,7 +555,11 @@ describe "Deserializing with the schema registry", :integration => true do
     let(:auth) { false }
     let(:avro_topic_name) { "topic_avro" }
     let(:subject_url) { "#{proto}://localhost:#{port}/subjects" }
-    let(:plain_config)  { base_config.merge!({'schema_registry_url' => "#{proto}://localhost:#{port}"}) }
+    let(:plain_config)  { base_config.merge!({
+      'schema_registry_url' => "#{proto}://localhost:#{port}",
+      'schema_registry_ssl_truststore_location' => File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+      'schema_registry_ssl_truststore_password' => 'changeit',
+    }) }
 
     it_behaves_like 'it reads from a topic using a schema registry', false
   end
@@ -584,7 +588,9 @@ describe "Deserializing with the schema registry", :integration => true do
         base_config.merge!({
           'schema_registry_url' => "#{proto}://localhost:#{port}",
           'schema_registry_key' => user,
-          'schema_registry_secret' => password
+          'schema_registry_secret' => password,
+          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+          'schema_registry_ssl_truststore_password' => 'changeit',
         })
       end
 
@@ -594,7 +600,9 @@ describe "Deserializing with the schema registry", :integration => true do
     context 'using schema_registry_url' do
       let(:plain_config) do
         base_config.merge!({
-          'schema_registry_url' => "#{proto}://#{user}:#{password}@localhost:#{port}"
+          'schema_registry_url' => "#{proto}://#{user}:#{password}@localhost:#{port}",
+          'schema_registry_ssl_truststore_location' => ::File.join(Dir.pwd, "tls_repository/clienttruststore.jks"),
+          'schema_registry_ssl_truststore_password' => 'changeit',
         })
       end
 

--- a/stop_schema_registry.sh
+++ b/stop_schema_registry.sh
@@ -2,6 +2,6 @@
 # Setup Kafka and create test topics
 set -ex
 
-echo "Stoppping SchemaRegistry"
+echo "Stopping SchemaRegistry"
 build/confluent_platform/bin/schema-registry-stop
 sleep 5


### PR DESCRIPTION
## Release notes
Add schema registry's setting for keystore and truststore.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This commit mainly exposes `location` `password` and `type` settings for schema registry's secret and key stores.
It brings those configuration options, if available, and directly forward down to the Kafka's SerDes library and Manticore client.
Introduces a script named `setup_keystore_and_truststore.sh` to setup keystore and truststore used in integration tests.
Furthermore it reworks a little bit the bash scripts to setup Kafka and Schema Registry in integration test to avoid download of artifacts if they are already locally downloaded.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
With this PR the user is able to configure trust and key stores to be used to connect and interact specifically with Schema Registry.
These stores are different from the one configured for the Kafka client.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] setup schema registry with separate keystore, import the certificate into client's truststore and verify that it can the plugin can connect to it running a pipeline.

## How to test this PR locally
To test this PR a couple of security settings has to be done. The best way to setup Kafka and Schema registry with key store is to launch the `kafka_test_setup.sh` and `./start_schema_registry.sh`. The script has the job to create keystore for schema registry, export it certificate and install on a truststore used by the client pipeline. All this security artifacts are available under the`./tls_repository` directory in plugin's clone.
1. clone the repo and launch:
```bash
./kafka_test_setup.sh
./start_schema_registry.sh
```
2. install a schema in the registry, for example
```
curl --location --request POST 'http://localhost:8081/subjects/logstash_test-value/versions' \
--header 'Content-Type: application/vnd.schemaregistry.v1+json' \
--data-raw '{"schema": "{\"namespace\": \"io.confluent.examples.clients.basicavro\", \"type\": \"record\", \"name\": \"Payment\", \"fields\": [     {\"name\": \"id\", \"type\": \"string\"},     {\"name\": \"amount\", \"type\": \"double\"} ]}"}'
```
  - if you want to use the HTTPS, add to the `curl`
```
--cacert /path/to/logstash-integration-kafka/tls/schema_reg_certificate.pem   
```
 -  point to port `8083` and switch protocol to`https`
3. in a local Logstash configure the Gemfile to point to the plugin:
  -  adds in `Gemfile`
```
gem "logstash-integration-kafka", :path => "/path/to/logstash-integration-kafka"
```
  - install it
```bash
bin/logstash-plugin install --no-verify
```
4. execute a pipeline with leverages the schema registry trust store setting:
```
input {
  kafka {
    bootstrap_servers => ["localhost:9092"]
    topics => ["logstash_test"]
    group_id => "logstash"
    consumer_threads => 2
    schema_registry_url => "https://localhost:8083/"
    schema_registry_ssl_truststore_location => "/path/to/logstash-integration-kafka/tls/clienttruststore.jks"
    schema_registry_ssl_truststore_password => "changeit"
    key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
  }
}


output {
  stdout {
    codec => rubydebug
  }
}
``` 
5. verify no errors happen in log

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #101 
- Relates https://github.com/confluentinc/schema-registry/pull/957

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->