### PR TITLE
Fix nil exception to empty headers during metadata assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2.1
+ - Fix nil exception to empty headers in metadata during event assignment
+
 ## 11.2.0
  - Added TLS truststore and keystore settings specifically to access the schema registry [#137](https://github.com/logstash-plugins/logstash-integration-kafka/pull/137)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.2.1
- - Fix nil exception to empty headers in metadata during event assignment
+ - Fix nil exception to empty headers of record during event metadata assignment [#140](https://github.com/logstash-plugins/logstash-integration-kafka/pull/140)
 
 ## 11.2.0
  - Added TLS truststore and keystore settings specifically to access the schema registry [#137](https://github.com/logstash-plugins/logstash-integration-kafka/pull/137)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -373,9 +373,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       event.set("[@metadata][kafka][timestamp]", record.timestamp)
     end
     if @metadata_mode.include?(:headers)
-      record.headers.each do |header|
-        next if header.nil? || header.value.nil? || header.key.nil?
-
+      record.headers
+            .select{|h| header_with_value(h) }
+            .each do |header|
         s = String.from_java_bytes(header.value)
         s.force_encoding(Encoding::UTF_8)
         if s.valid_encoding?
@@ -499,6 +499,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       end
       partition_assignment_strategy # assume a fully qualified class-name
     end
+  end
+
+  def header_with_value(header)
+    !header.nil? && !header.value.nil? && !header.key.nil?
   end
 
 end #class LogStash::Inputs::Kafka

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -374,6 +374,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     end
     if @metadata_mode.include?(:headers)
       record.headers.each do |header|
+        next if header.nil? || header.value.nil? || header.key.nil?
+
         s = String.from_java_bytes(header.value)
         s.force_encoding(Encoding::UTF_8)
         if s.valid_encoding?

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.2.0'
+  s.version         = '11.2.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -297,12 +297,8 @@ describe LogStash::Inputs::Kafka do
 
       evt = LogStash::Event.new('message' => 'Hello')
       headers = RecordHeaders.new
-      record = ConsumerRecord.new("topic".to_java, 0.to_java(java.lang.Integer),
-                                  1234567.to_java, 1676475552.to_java,
-                                  TimestampType::CREATE_TIME, 1234567.to_java,
-                                  0.to_java(java.lang.Integer), 0.to_java(java.lang.Integer),
-                                  "k".to_java(java.lang.Object), "v".to_java(java.lang.Object),
-                                  headers)
+      record = ConsumerRecord.new("topic", 0, 1234567, 1676475552, TimestampType::CREATE_TIME, 1234567,
+                                  0, 0, "k", "v", headers)
 
       expect { subject.maybe_set_metadata(evt, record) }.not_to raise_error
     end

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -288,19 +288,17 @@ describe LogStash::Inputs::Kafka do
       expect(subject.metadata_mode).to include(:record_props)
     end
 
-    it "guards against nil header" do
-      java_import org.apache.kafka.clients.consumer.ConsumerRecord
-      java_import org.apache.kafka.common.header.internals.RecordHeaders
-      java_import org.apache.kafka.common.record.TimestampType
+    context "guards against nil header" do
+      let(:header) { double(:value => nil, :key => "k") }
+      let(:headers) { [ header ] }
+      let(:record) { double(:headers => headers, :topic => "topic", :partition => 0,
+                            :offset => 123456789, :key => "someId", :timestamp => nil ) }
 
-      subject.register
-
-      evt = LogStash::Event.new('message' => 'Hello')
-      headers = RecordHeaders.new
-      record = ConsumerRecord.new("topic", 0, 1234567, 1676475552, TimestampType::CREATE_TIME, 1234567,
-                                  0, 0, "k", "v", headers)
-
-      expect { subject.maybe_set_metadata(evt, record) }.not_to raise_error
+      it "does not raise error when key is nil" do
+        subject.register
+        evt = LogStash::Event.new('message' => 'Hello')
+        expect { subject.maybe_set_metadata(evt, record) }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Fix: #141

This commit guard nil exception in metadata assignment