### PR TITLE
Potential typo in  output-kafka.asciidoc

### DIFF
--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -184,7 +184,7 @@ resolved and expanded into a list of canonical names.
 [NOTE]
 ====
 Starting from Kafka 3 `default` value for `client.dns.lookup` value has been removed.
-If explicitly configured it fallbacks to `use_all_dns_ips`.
+If not explicitly configured it fallbacks to `use_all_dns_ips`.
 ====
 
 [id="plugins-{type}s-{plugin}-client_id"]

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -184,7 +184,7 @@ resolved and expanded into a list of canonical names.
 [NOTE]
 ====
 Starting from Kafka 3 `default` value for `client.dns.lookup` value has been removed.
-If not explicitly configured it fallbacks to `use_all_dns_ips`.
+If not explicitly configured it defaults to `use_all_dns_ips`.
 ====
 
 [id="plugins-{type}s-{plugin}-client_id"]


### PR DESCRIPTION
Hi elastic team, I believe the behavior would be to fallback to use_all_dns_ips is NOT explicitly configured, use_all_dns_ips being the new default as its the AK default now, thank you

