### PR TITLE
Properly tag as integration some tests that requires Schema Registry service

### DIFF
--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -301,7 +301,7 @@ def consume_messages(config, queue: Queue.new, timeout:, event_count:)
 end
 
 
-describe "schema registry connection options" do
+describe "schema registry connection options", :integration => true do
   schema_registry = Manticore::Client.new
   before (:all) do
     shutdown_schema_registry


### PR DESCRIPTION
Adds the `:integration => true` tag to schema registry related tests to that they aren't run when executing:
```
bundle exec rspec --tag \"~integration\" --tag \"~secure_integration\"
```

The double quotes ar necessary to avoid shell expansion of `~` when launching from shell terminal.

- Closes #153 