### PR TITLE
Fix "Can't modify frozen string" error when record value is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 11.3.3
+  - Fix "Can't modify frozen string" error when record value is `nil` (tombstones) [#155](https://github.com/logstash-plugins/logstash-integration-kafka/pull/155)
+
 ## 11.3.2
-  - Fix: update Avro library [#150](https://api.github.com/repos/logstash-plugins/logstash-integration-kafka/pulls/150)
+  - Fix: update Avro library [#150](https://github.com/logstash-plugins/logstash-integration-kafka/pull/150)
 
 ## 11.3.1
   - Fix: update snappy dependency [#148](https://github.com/logstash-plugins/logstash-integration-kafka/pull/148)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -356,7 +356,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   end
 
   def handle_record(record, codec_instance, queue)
-    codec_instance.decode(record.value.to_s) do |event|
+    # use + since .to_s on nil/boolean returns a frozen string since ruby 2.7
+    codec_instance.decode(+record.value.to_s) do |event|
       decorate(event)
       maybe_set_metadata(event, record)
       queue << event

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.3.2'
+  s.version         = '11.3.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -134,6 +134,21 @@ describe LogStash::Inputs::Kafka do
       it 'should set the consumer thread name' do
         expect(subject.instance_variable_get('@runner_threads').first.get_name).to eq("kafka-input-worker-test-0")
       end
+
+      context 'with records value frozen' do
+        # boolean, module name & nil .to_s are frozen by default (https://bugs.ruby-lang.org/issues/16150)
+        let(:payload) do [
+          org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "nil", nil),
+          org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "true", true),
+          org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "false", false),
+          org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "frozen", "".freeze)
+        ]
+        end
+
+        it "should process events" do
+          expect(q.size).to eq(4)
+        end
+      end
     end
 
     context 'when errors are encountered during poll' do


### PR DESCRIPTION
This PR fixes the issue caused by the Ruby change https://bugs.ruby-lang.org/issues/16150, which made `boolean`, module name & `nil` `.to_s` values frozen by default, making this plugin unable to process Kafka "tombstone" records (a.k.a. a record with a `null` value).

#### How to test it locally?

1 - Set up the Kafka test environment:
```shell
./kafka_test_setup.sh
``` 
2 - Run the following pipeline config:
```yaml
 - pipeline.id: kafka
   config.string: |
     input {
       kafka {
         topics => "logstash_integration_topic_plain"
       }
     }

    output { stdout { codec => rubydebug { metadata => true } } }
```
3 - Produce a message with a null content:
```shell
echo "NULL" | build/kafka/bin/kafka-console-producer.sh --topic logstash_integration_topic_plain --broker-list localhost:9092 --property null.marker=NULL
```

Using the `main` branch code, it should terminate the pipeline and log an error similar to:

```
Exception in thread "kafka-input-worker-logstash-0" org.jruby.exceptions.FrozenError: (FrozenError) can't modify frozen String
	at org.jruby.RubyString.force_encoding(org/jruby/RubyString.java:6667)
	at org.jruby.RubyString.force_encoding(org/jruby/RubyString.java:6663)
```

The error should not happen using the fixed version.

---
Closes: https://github.com/logstash-plugins/logstash-integration-kafka/issues/155