### PR TITLE
Add default client_id of logstash to kafka output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.3.4
+  - Add default client_id of logstash to kafka output [#169](https://github.com/logstash-plugins/logstash-integration-kafka/pull/169)
+
 ## 11.4.1
   - [DOC] Match anchor ID and references for `message_headers` [#164](https://github.com/logstash-plugins/logstash-integration-kafka/pull/164)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.3.4
+## 11.4.2
   - Add default client_id of logstash to kafka output [#169](https://github.com/logstash-plugins/logstash-integration-kafka/pull/169)
 
 ## 11.4.1

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -192,7 +192,7 @@ If not explicitly configured it defaults to `use_all_dns_ips`.
 ===== `client_id` 
 
   * Value type is <<string,string>>
-  * There is no default value for this setting.
+  * Default value is `"logstash"`
 
 The id string to pass to the server when making requests.
 The purpose of this is to be able to track the source of requests beyond just

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -91,7 +91,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   # The id string to pass to the server when making requests.
   # The purpose of this is to be able to track the source of requests beyond just
   # ip/port by allowing a logical application name to be included with the request
-  config :client_id, :validate => :string
+  config :client_id, :validate => :string, :default => "logstash" 
   # Serializer class for the key of the message
   config :key_serializer, :validate => :string, :default => 'org.apache.kafka.common.serialization.StringSerializer'
   # The producer groups together any records that arrive in between request

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.4.1'
+  s.version         = '11.4.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
client_id defaults to `logstash` on the input, we should also default it to `logstash` on the output
