### PR TITLE
fix schema registry proxy handling

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -446,7 +446,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         props.put(serdes_config::SCHEMA_REGISTRY_URL_CONFIG, schema_registry_url.uri.to_s)
         if schema_registry_proxy && !schema_registry_proxy.empty?
           props.put(serdes_config::PROXY_HOST, @schema_registry_proxy_host)
-          props.put(serdes_config::PROXY_PORT, @schema_registry_proxy_port)
+          # Java Kafka client requires port to be a 32 bit int
+          props.put(serdes_config::PROXY_PORT, @schema_registry_proxy_port.to_java(Java::int))
         end
         if schema_registry_key && !schema_registry_key.empty?
           props.put(serdes_config::BASIC_AUTH_CREDENTIALS_SOURCE, 'USER_INFO')

--- a/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
+++ b/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb
@@ -99,7 +99,7 @@ module LogStash module PluginMixins module Kafka
         options[:ssl][:keystore_type] = schema_registry_ssl_keystore_type unless schema_registry_ssl_keystore_type.nil?
       end
 
-      registered_subjects = retrieve_subjects
+      registered_subjects = retrieve_subjects(options)
       expected_subjects = @topics.map { |t| "#{t}-value"}
       if (expected_subjects & registered_subjects).size != expected_subjects.size
         undefined_topic_subjects = expected_subjects - registered_subjects
@@ -107,7 +107,7 @@ module LogStash module PluginMixins module Kafka
       end
     end
 
-    def retrieve_subjects
+    def retrieve_subjects(options)
       client = Manticore::Client.new(options)
       response = client.get(@schema_registry_url.uri.to_s + '/subjects').body
       JSON.parse response

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -287,6 +287,22 @@ describe LogStash::Inputs::Kafka do
         end
       end
     end
+    context "when schema_registry_proxy is enabled" do
+      let(:schema_registry_proxy_url) { "http://myproxy:3333" }
+      let(:config) { base_config.merge('schema_registry_proxy' => schema_registry_proxy_url) }
+
+      it "doesn't raise error on register" do
+        expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
+        expect { subject.register }.to_not raise_error
+      end
+
+      it "extracts the correct proxy host and port" do
+        expect(subject).to receive(:check_for_schema_registry_connectivity_and_subjects)
+        subject.register
+        expect(subject.instance_variable_get('@schema_registry_proxy_host')).to eq('myproxy')
+        expect(subject.instance_variable_get('@schema_registry_proxy_port')).to eq(3333)
+      end
+    end
   end
 
   context "decorate_events" do


### PR DESCRIPTION
change `schema_registry_proxy` setting from uri to string to move URI validation further down so that "" is an acceptable value. accepting "" is useful when doing something like:

```
  schema_registry_proxy => "%{SCHEMA_REGISTRY_PROXY}"
```
But depending on environment that env var may be empty. This removes the need for templating.

To support this we need to validate the URI a bit later.

Also this PR removes uri handling of https and basic auth for the proxy url given that the schema registry itself doesn't support it either (see https://github.com/confluentinc/schema-registry/issues/2137)

fixes #144 