### PR TITLE
docs: clarify limitations of header decoration

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -286,7 +286,7 @@ This will add a field named `kafka` to the logstash event containing the followi
 * `offset`: The offset from the partition this message is associated with
 * `key`: A ByteBuffer containing the message key
 
-NOTE: When adding headers, only headers whose values are valid UTF-8 byte sequences are included.
+NOTE: Only headers whose values are valid UTF-8 byte sequences are included.
       If an event has multiple headers with the same key, at most one will be included.
 
 [id="plugins-{type}s-{plugin}-auto_create_topics"]

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -286,6 +286,8 @@ This will add a field named `kafka` to the logstash event containing the followi
 * `offset`: The offset from the partition this message is associated with
 * `key`: A ByteBuffer containing the message key
 
+NOTE: When adding headers, only headers whose values are valid UTF-8 byte sequences are included.
+      If an event has multiple headers with the same key, at most one will be included.
 
 [id="plugins-{type}s-{plugin}-auto_create_topics"]
 ===== `auto_create_topics` 


### PR DESCRIPTION
Two known limitations with headers:

1. Only headers whose values are utf-8 byte sequences will be added to the event ([impl](https://github.com/logstash-plugins/logstash-integration-kafka/blob/v11.5.0/lib/logstash/inputs/kafka.rb#L386-L390)).
   While in theory this could change in the future, receiving anything other than a known-constant encoding is problematic for a variety of reasons and likely the reason for the current implementation (e.g., not being embeddable in JSON without loss, which precludes sending the raw bytes to Elasticsearch or other outputs).
3. Kafka allows multiple headers to share a key, but as-implemented we will overwrite a key if we observe and set it twice.