### PR TITLE
sasl.oauthbearer.token.endpoint.url Kafka client setting to set oauth…

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -131,6 +131,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
@@ -562,6 +563,13 @@ to a given topic partition. This avoids repeated fetching-and-failing in a tight
 * There is no default value for this setting.
 
 The SASL client callback handler class the specified SASL mechanism should use.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url""]
+===== `sasl_oauthbearer_token_endpoint_url`
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The URL where the Kafka client requests OAuth 2.0 tokens from an authorization server for integration with OAuth 2.0 identity providers.
 
 [id="plugins-{type}s-{plugin}-sasl_jaas_config"]
 ===== `sasl_jaas_config` 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -102,6 +102,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
@@ -398,6 +399,13 @@ The amount of time to wait before attempting to retry a failed produce request t
 * There is no default value for this setting.
 
 The SASL client callback handler class the specified SASL mechanism should use.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url""]
+===== `sasl_oauthbearer_token_endpoint_url`
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The URL where the Kafka client requests OAuth 2.0 tokens from an authorization server for integration with OAuth 2.0 identity providers.
 
 [id="plugins-{type}s-{plugin}-sasl_jaas_config"]
 ===== `sasl_jaas_config` 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -210,6 +210,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :security_protocol, :validate => ["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"], :default => "PLAINTEXT"
   # SASL client callback handler class
   config :sasl_client_callback_handler_class, :validate => :string
+  # The URL where the Kafka client requests OAuth 2.0 tokens from an authorization server.
+  config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -149,6 +149,8 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :security_protocol, :validate => ["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"], :default => "PLAINTEXT"
   # SASL client callback handler class
   config :sasl_client_callback_handler_class, :validate => :string
+  # The URL where the Kafka client requests OAuth 2.0 tokens from an authorization server.
+  config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/plugin_mixins/kafka/common.rb
+++ b/lib/logstash/plugin_mixins/kafka/common.rb
@@ -42,6 +42,7 @@ module LogStash module PluginMixins module Kafka
       props.put("sasl.kerberos.service.name", sasl_kerberos_service_name) unless sasl_kerberos_service_name.nil?
       props.put("sasl.jaas.config", sasl_jaas_config) unless sasl_jaas_config.nil?
       props.put("sasl.client.callback.handler.class", sasl_client_callback_handler_class) unless sasl_client_callback_handler_class.nil?
+      props.put("sasl.oauthbearer.token.endpoint.url", sasl_oauthbearer_token_endpoint_url) unless sasl_oauthbearer_token_endpoint_url.nil?
     end
 
     def reassign_dns_lookup


### PR DESCRIPTION
…bearer token endpoint url

like PR https://github.com/logstash-plugins/logstash-integration-kafka/pull/177, i also want to add sasl_oauthbearer_token_endpoint_url.
