### PR TITLE
Add fine tuned oath/sasl configuration to kafka client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.6.0
+  - Support additional `oauth` and `sasl` configuration options for configuring kafka client [#189](https://github.com/logstash-plugins/logstash-integration-kafka/pull/189)
+
 ## 11.5.4
   - Update kafka client to 3.8.1 and transitive dependencies [#188](https://github.com/logstash-plugins/logstash-integration-kafka/pull/188)
   - Removed Jar Dependencies dependency [#187](https://github.com/logstash-plugins/logstash-integration-kafka/pull/187)

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -600,6 +600,7 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
 ===== `sasl_login_read_timeout_ms`
   * Value type is <<number,number>>
+  * There is no default value for this setting.
 
 (optional) The duration, in milliseconds, for HTTPS read timeout.
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -131,6 +131,12 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_read_timeout_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_max_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
@@ -556,12 +562,54 @@ retries are exhausted.
 The amount of time to wait before attempting to retry a failed fetch request
 to a given topic partition. This avoids repeated fetching-and-failing in a tight loop.
 
-[id="plugins-{type}s-{plugin}-sasl_client_callback_handler_class""]
+[id="plugins-{type}s-{plugin}-sasl_client_callback_handler_class"]
 ===== `sasl_client_callback_handler_class`
-* Value type is <<string,string>>
-* There is no default value for this setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
 
 The SASL client callback handler class the specified SASL mechanism should use.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url"]
+===== `sasl_oauthbearer_token_endpoint_url`
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The URL for the OAuth 2.0 issuer token endpoint.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name"]
+===== `sasl_oauthbearer_scope_claim_name`
+  * Value type is <<string,string>>
+  * Default value is `"scope"`
+
+(optional) The override name of the scope claim.
+
+[id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
+===== `sasl_login_connect_timeout_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The duration, in milliseconds, for HTTPS connect timeout
+
+[id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
+===== `sasl_login_read_timeout_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The duration, in milliseconds, for HTTPS read timeout.
+
+[id="plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms"]
+===== `sasl_login_retry_backoff_ms`
+  * Value type is <<number,number>>
+  * Default value is `100` milliseconds.
+
+(optional) The duration, in milliseconds, to wait between HTTPS call attempts.
+
+[id="plugins-{type}s-{plugin}-sasl_login_retry_backoff_max_ms"]
+===== `sasl_login_retry_backoff_max_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The maximum duration, in milliseconds, for HTTPS call attempts.
 
 [id="plugins-{type}s-{plugin}-sasl_jaas_config"]
 ===== `sasl_jaas_config` 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -594,14 +594,12 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`
   * Value type is <<number,number>>
-  * Default value is `10000` milliseconds.
 
 (optional) The duration, in milliseconds, for HTTPS connect timeout
 
 [id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
 ===== `sasl_login_read_timeout_ms`
   * Value type is <<number,number>>
-  * Default value is `10000` milliseconds.
 
 (optional) The duration, in milliseconds, for HTTPS read timeout.
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -594,6 +594,7 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`
   * Value type is <<number,number>>
+  * There is no default value for this setting.
 
 (optional) The duration, in milliseconds, for HTTPS connect timeout
 

--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -133,6 +133,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_callback_handler_class>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_read_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms>> |<<number,number>>|No
@@ -582,6 +583,13 @@ The URL for the OAuth 2.0 issuer token endpoint.
   * Default value is `"scope"`
 
 (optional) The override name of the scope claim.
+
+[id="plugins-{type}s-{plugin}-sasl_login_callback_handler_class"]
+===== `sasl_login_callback_handler_class`
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The SASL login callback handler class the specified SASL mechanism should use.
 
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -104,6 +104,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_callback_handler_class>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_read_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms>> |<<number,number>>|No
@@ -418,6 +419,13 @@ The URL for the OAuth 2.0 issuer token endpoint.
   * Default value is `"scope"`
 
 (optional) The override name of the scope claim.
+
+[id="plugins-{type}s-{plugin}-sasl_login_callback_handler_class"]
+===== `sasl_login_callback_handler_class`
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The SASL login callback handler class the specified SASL mechanism should use.
 
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -437,6 +437,7 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
 ===== `sasl_login_read_timeout_ms`
   * Value type is <<number,number>>
+  * There is no default value for this setting.
 
 (optional) The duration, in milliseconds, for HTTPS read timeout.
 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -430,6 +430,7 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`
   * Value type is <<number,number>>
+  * There is no default value for this setting.
 
 (optional) The duration, in milliseconds, for HTTPS connect timeout
 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -102,6 +102,12 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_client_callback_handler_class>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_read_timeout_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_login_retry_backoff_max_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
@@ -392,12 +398,54 @@ In versions prior to 10.5.0, any exception is retried indefinitely unless the `r
 
 The amount of time to wait before attempting to retry a failed produce request to a given topic partition.
 
-[id="plugins-{type}s-{plugin}-sasl_client_callback_handler_class""]
+[id="plugins-{type}s-{plugin}-sasl_client_callback_handler_class"]
 ===== `sasl_client_callback_handler_class`
-* Value type is <<string,string>>
-* There is no default value for this setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
 
 The SASL client callback handler class the specified SASL mechanism should use.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_token_endpoint_url"]
+===== `sasl_oauthbearer_token_endpoint_url`
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The URL for the OAuth 2.0 issuer token endpoint.
+
+[id="plugins-{type}s-{plugin}-sasl_oauthbearer_scope_claim_name"]
+===== `sasl_oauthbearer_scope_claim_name`
+  * Value type is <<string,string>>
+  * Default value is `"scope"`
+
+(optional) The override name of the scope claim.
+
+[id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
+===== `sasl_login_connect_timeout_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The duration, in milliseconds, for HTTPS connect timeout
+
+[id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
+===== `sasl_login_read_timeout_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The duration, in milliseconds, for HTTPS read timeout.
+
+[id="plugins-{type}s-{plugin}-sasl_login_retry_backoff_ms"]
+===== `sasl_login_retry_backoff_ms`
+  * Value type is <<number,number>>
+  * Default value is `100` milliseconds.
+
+(optional) The duration, in milliseconds, to wait between HTTPS call attempts.
+
+[id="plugins-{type}s-{plugin}-sasl_login_retry_backoff_max_ms"]
+===== `sasl_login_retry_backoff_max_ms`
+  * Value type is <<number,number>>
+  * Default value is `10000` milliseconds.
+
+(optional) The maximum duration, in milliseconds, for HTTPS call attempts.
 
 [id="plugins-{type}s-{plugin}-sasl_jaas_config"]
 ===== `sasl_jaas_config` 

--- a/docs/output-kafka.asciidoc
+++ b/docs/output-kafka.asciidoc
@@ -430,14 +430,12 @@ The SASL login callback handler class the specified SASL mechanism should use.
 [id="plugins-{type}s-{plugin}-sasl_login_connect_timeout_ms"]
 ===== `sasl_login_connect_timeout_ms`
   * Value type is <<number,number>>
-  * Default value is `10000` milliseconds.
 
 (optional) The duration, in milliseconds, for HTTPS connect timeout
 
 [id="plugins-{type}s-{plugin}-sasl_login_read_timeout_ms"]
 ===== `sasl_login_read_timeout_ms`
   * Value type is <<number,number>>
-  * Default value is `10000` milliseconds.
 
 (optional) The duration, in milliseconds, for HTTPS read timeout.
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -214,6 +214,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # (optional) The override name of the scope claim.
   config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  # SASL login callback handler class
+  config :sasl_login_callback_handler_class, :validate => :string
   # (optional) The duration, in milliseconds, for HTTPS connect timeout
   config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
   # (optional) The duration, in milliseconds, for HTTPS read timeout.

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -210,6 +210,18 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :security_protocol, :validate => ["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"], :default => "PLAINTEXT"
   # SASL client callback handler class
   config :sasl_client_callback_handler_class, :validate => :string
+  # The URL for the OAuth 2.0 issuer token endpoint.
+  config :sasl_oauthbearer_token_endpoint_url, :validate => :string
+  # (optional) The override name of the scope claim.
+  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  # (optional) The duration, in milliseconds, for HTTPS connect timeout
+  config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
+  # (optional) The duration, in milliseconds, for HTTPS read timeout.
+  config :sasl_login_read_timeout_ms, :validate => :number, :default => 10000
+  # (optional) The duration, in milliseconds, to wait between HTTPS call attempts.
+  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100
+  # (optional) The maximum duration, in milliseconds, for HTTPS call attempts.
+  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -213,17 +213,17 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # The URL for the OAuth 2.0 issuer token endpoint.
   config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # (optional) The override name of the scope claim.
-  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope' # Kafka default
   # SASL login callback handler class
   config :sasl_login_callback_handler_class, :validate => :string
   # (optional) The duration, in milliseconds, for HTTPS connect timeout
-  config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
+  config :sasl_login_connect_timeout_ms, :validate => :number
   # (optional) The duration, in milliseconds, for HTTPS read timeout.
-  config :sasl_login_read_timeout_ms, :validate => :number, :default => 10000
+  config :sasl_login_read_timeout_ms, :validate => :number
   # (optional) The duration, in milliseconds, to wait between HTTPS call attempts.
-  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100
+  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100 # Kafka default
   # (optional) The maximum duration, in milliseconds, for HTTPS call attempts.
-  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000
+  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000 # Kafka default
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -153,6 +153,8 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # (optional) The override name of the scope claim.
   config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  # SASL login callback handler class
+  config :sasl_login_callback_handler_class, :validate => :string
   # (optional) The duration, in milliseconds, for HTTPS connect timeout
   config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
   # (optional) The duration, in milliseconds, for HTTPS read timeout.

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -152,17 +152,17 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   # The URL for the OAuth 2.0 issuer token endpoint.
   config :sasl_oauthbearer_token_endpoint_url, :validate => :string
   # (optional) The override name of the scope claim.
-  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope' # Kafka default
   # SASL login callback handler class
   config :sasl_login_callback_handler_class, :validate => :string
   # (optional) The duration, in milliseconds, for HTTPS connect timeout
-  config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
+  config :sasl_login_connect_timeout_ms, :validate => :number
   # (optional) The duration, in milliseconds, for HTTPS read timeout.
-  config :sasl_login_read_timeout_ms, :validate => :number, :default => 10000
+  config :sasl_login_read_timeout_ms, :validate => :number
   # (optional) The duration, in milliseconds, to wait between HTTPS call attempts.
-  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100
+  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100 # Kafka default
   # (optional) The maximum duration, in milliseconds, for HTTPS call attempts.
-  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000
+  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000 # Kafka default
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -149,6 +149,18 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :security_protocol, :validate => ["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"], :default => "PLAINTEXT"
   # SASL client callback handler class
   config :sasl_client_callback_handler_class, :validate => :string
+  # The URL for the OAuth 2.0 issuer token endpoint.
+  config :sasl_oauthbearer_token_endpoint_url, :validate => :string
+  # (optional) The override name of the scope claim.
+  config :sasl_oauthbearer_scope_claim_name, :validate => :string, :default => 'scope'
+  # (optional) The duration, in milliseconds, for HTTPS connect timeout
+  config :sasl_login_connect_timeout_ms, :validate => :number, :default => 10000
+  # (optional) The duration, in milliseconds, for HTTPS read timeout.
+  config :sasl_login_read_timeout_ms, :validate => :number, :default => 10000
+  # (optional) The duration, in milliseconds, to wait between HTTPS call attempts.
+  config :sasl_login_retry_backoff_ms, :validate => :number, :default => 100
+  # (optional) The maximum duration, in milliseconds, for HTTPS call attempts.
+  config :sasl_login_retry_backoff_max_ms, :validate => :number, :default => 10000
   # http://kafka.apache.org/documentation.html#security_sasl[SASL mechanism] used for client connections. 
   # This may be any mechanism for which a security provider is available.
   # GSSAPI is the default mechanism.

--- a/lib/logstash/plugin_mixins/kafka/common.rb
+++ b/lib/logstash/plugin_mixins/kafka/common.rb
@@ -44,6 +44,7 @@ module LogStash module PluginMixins module Kafka
       props.put("sasl.client.callback.handler.class", sasl_client_callback_handler_class) unless sasl_client_callback_handler_class.nil?
       props.put("sasl.oauthbearer.token.endpoint.url", sasl_oauthbearer_token_endpoint_url) unless sasl_oauthbearer_token_endpoint_url.nil?
       props.put("sasl.oauthbearer.scope.claim.name", sasl_oauthbearer_scope_claim_name) unless sasl_oauthbearer_scope_claim_name.nil?
+      props.put("sasl.login.callback.handler.class", sasl_login_callback_handler_class) unless sasl_login_callback_handler_class.nil?
       props.put("sasl.login.connect.timeout.ms", sasl_login_connect_timeout_ms.to_s) unless sasl_login_connect_timeout_ms.nil?
       props.put("sasl.login.read.timeout.ms", sasl_login_read_timeout_ms.to_s) unless sasl_login_read_timeout_ms.nil?
       props.put("sasl.login.retry.backoff.ms", sasl_login_retry_backoff_ms.to_s) unless sasl_login_retry_backoff_ms.nil?

--- a/lib/logstash/plugin_mixins/kafka/common.rb
+++ b/lib/logstash/plugin_mixins/kafka/common.rb
@@ -42,6 +42,12 @@ module LogStash module PluginMixins module Kafka
       props.put("sasl.kerberos.service.name", sasl_kerberos_service_name) unless sasl_kerberos_service_name.nil?
       props.put("sasl.jaas.config", sasl_jaas_config) unless sasl_jaas_config.nil?
       props.put("sasl.client.callback.handler.class", sasl_client_callback_handler_class) unless sasl_client_callback_handler_class.nil?
+      props.put("sasl.oauthbearer.token.endpoint.url", sasl_oauthbearer_token_endpoint_url) unless sasl_oauthbearer_token_endpoint_url.nil?
+      props.put("sasl.oauthbearer.scope.claim.name", sasl_oauthbearer_scope_claim_name) unless sasl_oauthbearer_scope_claim_name.nil?
+      props.put("sasl.login.connect.timeout.ms", sasl_login_connect_timeout_ms.to_s) unless sasl_login_connect_timeout_ms.nil?
+      props.put("sasl.login.read.timeout.ms", sasl_login_read_timeout_ms.to_s) unless sasl_login_read_timeout_ms.nil?
+      props.put("sasl.login.retry.backoff.ms", sasl_login_retry_backoff_ms.to_s) unless sasl_login_retry_backoff_ms.nil?
+      props.put("sasl.login.retry.backoff.max.ms", sasl_login_retry_backoff_max_ms.to_s) unless sasl_login_retry_backoff_max_ms.nil?
     end
 
     def reassign_dns_lookup

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.5.4'
+  s.version         = '11.6.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Add plugin configuration options for both input/output to support oauth and sasl authentication. 

This PR aggregates https://github.com/logstash-plugins/logstash-integration-kafka/pull/183 and https://github.com/logstash-plugins/logstash-integration-kafka/pull/181 and adds some unit tests. 

I found it difficult to spin up a valid test environment to fully test the integrations, but looking at the options in https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java I think the added unit tests show that we are piping through the requested configuration to the kafka clients. 

Closes https://github.com/logstash-plugins/logstash-integration-kafka/issues/180