### PR TITLE
Add `on_shutdown` with options `abandon` and `release`

### DIFF
--- a/docs/input-kafka.asciidoc
+++ b/docs/input-kafka.asciidoc
@@ -141,6 +141,7 @@ See the https://kafka.apache.org/{kafka_client_doc}/documentation for more detai
 | <<plugins-{type}s-{plugin}-max_poll_interval_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-max_poll_records>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-metadata_max_age_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-on_shutdown>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-partition_assignment_strategy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-poll_timeout_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-receive_buffer_bytes>> |<<number,number>>|No
@@ -512,6 +513,15 @@ The maximum number of records returned in a single call to poll().
 
 The period of time in milliseconds after which we force a refresh of metadata even if
 we haven't seen any partition leadership changes to proactively discover any new brokers or partitions
+
+[id="plugins-{type}s-{plugin}-on_shutdown"]
+===== `on_shutdown`
+
+* Value type is <<string,string>>
+* Accepted values are:
+- `release`: releases assigned partitions to make them immediately available to other consumers in the group
+- `abandon`: avoid explicitly releasing assigned partitions, allowing sticky-type <<plugins-{type}s-{plugin}-partition_assignment_strategy>> to retain partition assignments across process or pipeline restarts.
+* The default value is `abandon`
 
 [id="plugins-{type}s-{plugin}-partition_assignment_strategy"]
 ===== `partition_assignment_strategy` 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -270,6 +270,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # otherwise auto-topic creation is not permitted.
   config :auto_create_topics, :validate => :boolean, :default => true
 
+  # controls consumer behaviour on shutdown
+  #  - abandon: close consumer without unsubscribing
+  #  - release: unsubscribe before closing consumer
+  config :on_shutdown, :validate => %w(release abandon), :default => 'abandon'
+
   config :decorate_events, :validate => %w(none basic extended false true), :default => "none"
 
   attr_reader :metadata_mode
@@ -355,6 +360,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
           end
         end
       ensure
+        consumer.unsubscribe if @on_shutdown == 'release'
         consumer.close
       end
     end

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -93,6 +93,15 @@ describe LogStash::Inputs::Kafka do
         expect(subject.client_dns_lookup).to eq('use_all_dns_ips')
       end
     end
+
+    context '#on_shutdown' do
+      let(:registered_kafka_input) { subject.tap(&:register) }
+      it 'defaults to `abandon`' do
+        # BACKWARD-COMPATIBILITY: defaulting to a value other than `abandon` has
+        # side-effects for sticky partition strategies and static partition assignments
+        expect(registered_kafka_input.on_shutdown).to eq('abandon')
+      end
+    end
   end
 
   describe '#running' do


### PR DESCRIPTION
In some configurations, it would be helpful for the input plugin's consumers to unsubscribe from their topics during shutdown, especially with sticky-type partition assignment strategies with non-static group membership. 

This would allow the consumer's assigned partitions to be _immediately_ eligible to be assigned to another member of the group, instead of needing to wait out broker-side timeouts.

This patch introduces a new option `on_shutdown`, with two options:
 - `release`: revoke all current subscriptions, releasing the assigned partitions so that they can be immediately assigned to another member of the group
 - `abandon` (backward-compatible default): leave the subscription in-tact when closing, allowing broker to begin reassigning these partitions in its own time

