### PR TITLE
Displays chain of errors coming from kafka client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.6.4
+  - Display exception chain comes from kafka client [#200](https://github.com/logstash-plugins/logstash-integration-kafka/pull/200)
+
 ## 11.6.3
   - Update kafka client to 3.9.1 and transitive dependencies [#193](https://github.com/logstash-plugins/logstash-integration-kafka/pull/193)
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -391,9 +391,16 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
       org.apache.kafka.clients.producer.KafkaProducer.new(props)
     rescue => e
+      cause_error = e.respond_to?(:getCause) ? e.getCause() : nil
       logger.error("Unable to create Kafka producer from given configuration",
                    :kafka_error_message => e,
-                   :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
+                   :cause => cause_error)
+      while cause_error != nil
+        logger.error("Kafka producer error chain",
+                     :kafka_error_message => cause_error,
+                     :cause => cause_error)
+        cause_error = cause_error.respond_to?(:getCause) ? cause_error.getCause() : nil
+      end
       raise e
     end
   end

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -391,14 +391,9 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
       org.apache.kafka.clients.producer.KafkaProducer.new(props)
     rescue => e
-      cause_error = e.respond_to?(:getCause) ? e.getCause() : nil
-      logger.error("Unable to create Kafka producer from given configuration",
-                   :kafka_error_message => e,
-                   :cause => cause_error)
-      while cause_error != nil
-        logger.error("Kafka producer error chain",
-                     :kafka_error_message => cause_error,
-                     :cause => cause_error)
+      cause_error = e
+      while cause_error
+        logger.error("Kafka producer error chain", :kafka_error_message => "#{cause_error.class}: #{cause_error.message}")
         cause_error = cause_error.respond_to?(:getCause) ? cause_error.getCause() : nil
       end
       raise e

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '11.6.3'
+  s.version         = '11.6.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
### Description
Current implementation hides the detail errors coming from kafka-client when initializing a producer. Kafka client creates a chain of `KafkaException`s (e.g `KafkaException("message", new KafkaException("NetworkClient error", new KafkaException())`) but current following line shows only first error.
```
logger.error("Unable to create Kafka producer from given configuration",
                   :kafka_error_message => e,
                   :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
```

We need iterate over error chains and show to provide descriptive error messages.

With this PR , we get chain of exception details. For the example when password is incorrect, we get `keystore password was incorrect` in the chain errors.
```
logstash  | [2025-08-27T22:20:02,962][ERROR][logstash.outputs.kafka   ][main] Unable to create Kafka producer from given configuration {:kafka_error_message=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to construct kafka producer>, :cause=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to create new NetworkClient>}
logstash  | [2025-08-27T22:20:02,962][ERROR][logstash.outputs.kafka   ][main] Kafka producer error chain {:kafka_error_message=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to create new NetworkClient>, :cause=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to create new NetworkClient>}
logstash  | [2025-08-27T22:20:02,963][ERROR][logstash.outputs.kafka   ][main] Kafka producer error chain {:kafka_error_message=>#<Java::OrgApacheKafkaCommon::KafkaException: org.apache.kafka.common.KafkaException: Failed to load SSL keystore /usr/share/logstash/kerberos/ssl/logstash.keystore.jks of type JKS>, :cause=>#<Java::OrgApacheKafkaCommon::KafkaException: org.apache.kafka.common.KafkaException: Failed to load SSL keystore /usr/share/logstash/kerberos/ssl/logstash.keystore.jks of type JKS>}
logstash  | [2025-08-27T22:20:02,963][ERROR][logstash.outputs.kafka   ][main] Kafka producer error chain {:kafka_error_message=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to load SSL keystore /usr/share/logstash/kerberos/ssl/logstash.keystore.jks of type JKS>, :cause=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to load SSL keystore /usr/share/logstash/kerberos/ssl/logstash.keystore.jks of type JKS>}
logstash  | [2025-08-27T22:20:02,963][ERROR][logstash.outputs.kafka   ][main] Kafka producer error chain {:kafka_error_message=>#<Java::JavaIo::IOException: keystore password was incorrect>, :cause=>#<Java::JavaIo::IOException: keystore password was incorrect>}
logstash  | [2025-08-27T22:20:02,963][ERROR][logstash.outputs.kafka   ][main] Kafka producer error chain {:kafka_error_message=>#<Java::JavaSecurity::UnrecoverableKeyException: failed to decrypt safe contents entry: javax.crypto.BadPaddingException: Given final block not properly padded. Such issues can arise if a bad key is used during decryption.>, :cause=>#<Java::JavaSecurity::UnrecoverableKeyException: failed to decrypt safe contents entry: javax.crypto.BadPaddingException: Given final block not properly padded. Such issues can arise if a bad key is used during decryption.>}
logstash  | [2025-08-27T22:20:02,964][ERROR][logstash.javapipeline    ][main] Pipeline error {:pipeline_id=>"main", :exception=>#<Java::OrgApacheKafkaCommon::KafkaException: Failed to construct kafka producer>, :backtrace=>["org.apache.kafka.clients.producer.KafkaProducer.<init>(org/apache/kafka/clients/producer/KafkaProducer.java:476)", "org.apache.kafka.clients.producer.KafkaProducer.<init>(org/apache/kafka/clients/producer/KafkaProducer.java:297)", "org.apache.kafka.clients.producer.KafkaProducer.<init>(org/apache/kafka/clients/producer/KafkaProducer.java:324)", "org.apache.kafka.clients.producer.KafkaProducer.<init>(org/apache/kafka/clients/producer/KafkaProducer.java:309)", "jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(jdk/internal/reflect/DirectConstructorHandleAccessor.java:62)", "java.lang.reflect.Constructor.newInstanceWithCaller(java/lang/reflect/Constructor.java:502)", "java.lang.reflect.Constructor.newInstance(java/lang/reflect/Constructor.java:486)", "org.jruby.javasupport.JavaConstructor.newInstanceDirect(org/jruby/javasupport/JavaConstructor.java:165)", "org.jruby.RubyClass.new(org/jruby/RubyClass.java:922)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(org/jruby/RubyClass$INVOKER$i$newInstance.gen)", "RUBY.create_producer(/usr/share/logstash/vendor/local_gems/6f22f708/logstash-integration-kafka-11.6.4-universal.arm64e-darwin-24/lib/logstash/outputs/kafka.rb:392)", "RUBY.register(/usr/share/logstash/vendor/local_gems/6f22f708/logstash-integration-kafka-11.6.4-universal.arm64e-darwin-24/lib/logstash/outputs/kafka.rb:232)", "org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:598)", "org.jruby.RubyBasicObject.callMethod(org/jruby/RubyBasicObject.java:349)", "org.logstash.config.ir.compiler.OutputStrategyExt$SimpleAbstractOutputStrategyExt.reg(org/logstash/config/ir/compiler/OutputStrategyExt.java:275)", "org.logstash.config.ir.compiler.OutputStrategyExt$AbstractOutputStrategyExt.register(org/logstash/config/ir/compiler/OutputStrategyExt.java:131)", "org.logstash.config.ir.compiler.OutputDelegatorExt.doRegister(org/logstash/config/ir/compiler/OutputDelegatorExt.java:126)", "org.logstash.config.ir.compiler.AbstractOutputDelegatorExt.register(org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:69)", "org.logstash.config.ir.compiler.AbstractOutputDelegatorExt$INVOKER$i$0$0$register.call(org/logstash/config/ir/compiler/AbstractOutputDelegatorExt$INVOKER$i$0$0$register.gen)", "RUBY.register_plugins(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:245)", "org.jruby.RubyArray.each(org/jruby/RubyArray.java:1981)", "org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)", "RUBY.register_plugins(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:244)", "RUBY.maybe_setup_out_plugins(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:622)", "RUBY.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:257)", "RUBY.run(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:198)", "RUBY.start(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:150)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:354)", "java.lang.Thread.run(java/lang/Thread.java:1583)"], "pipeline.sources"=>["/usr/share/logstash/config/kafkaout-kerberos.conf"], :thread=>"#<Thread:0x58af5758 /usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:138 run>"}
```