### PR TITLE
Remove duplicated deprecation log entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.1
+  - Remove duplicated deprecation log entry [#208](https://github.com/logstash-plugins/logstash-integration-kafka/pull/208)
+
 ## 12.0.0
   - Update kafka client to 4.1.0 and transitive dependencies [#205](https://github.com/logstash-plugins/logstash-integration-kafka/pull/205)
     - Breaking Change: partitioner options `default` and `uniform_sticky` are removed

--- a/lib/logstash/plugin_mixins/kafka/common.rb
+++ b/lib/logstash/plugin_mixins/kafka/common.rb
@@ -55,8 +55,7 @@ module LogStash module PluginMixins module Kafka
     def reassign_dns_lookup
       if @client_dns_lookup == "default"
         @client_dns_lookup = "use_all_dns_ips"
-        logger.warn("client_dns_lookup setting 'default' value is deprecated, forced to 'use_all_dns_ips', please update your configuration")
-        deprecation_logger.deprecated("Deprecated value `default` for `client_dns_lookup` option; use `use_all_dns_ips` instead.")
+        deprecation_logger.deprecated("Deprecated value `default` for `client_dns_lookup` option; please update your configuration to use `use_all_dns_ips` instead.")
       end
     end
 

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '12.0.0'
+  s.version         = '12.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Last [change on logstash core logger config](https://github.com/elastic/logstash/pull/18326) wires deprecation logger to plain logger by default. It is not needed to duplicate deprecation logs anymore because any call to `deprecation_logger.deprecated()` will log in plain logger output as well unless user changes this default configuration.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
