### PR TITLE
Bump lz4 version to fix CVE-2025-12183 and CVE-2025-66566

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     // slf4j, zstd, lz4-java, and snappy are dependencies from "kafka-clients"
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.github.luben:zstd-jni:1.5.6-10'
-    implementation 'at.yawk.lz4:lz4-java:1.8.1'
+    implementation 'at.yawk.lz4:lz4-java:1.10.1'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.7'
 }
 task generateGemJarRequiresFile {


### PR DESCRIPTION
CVE-2025-12183: Various lz4-java compression and decompression implementations do not guard against out-of-bounds memory access. Untrusted input may lead to denial of service and information disclosure.

Note: The official lz4-java project has been discontinued. A community fork is available [here](https://github.com/yawkat/lz4-java). To address [CVE-2025-12183](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183), Sonatype has added a redirect from org.lz4:lz4-java:1.8.1 to the new group ID.

CVE-2025-66566: Insufficient clearing of the output buffer in Java-based decompressor implementations in lz4-java 1.10.0 and earlier allows remote attackers to read previous buffer contents via crafted compressed input. In applications where the output buffer is reused without being cleared, this may lead to disclosure of sensitive data.