### PR TITLE
Replace lz4 with maintained provider and upgrade it to 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.2
+  - Upgrade lz4 dependency [#212](https://github.com/logstash-plugins/logstash-integration-kafka/pull/212)
+
 ## 12.0.1
   - Remove duplicated deprecation log entry [#208](https://github.com/logstash-plugins/logstash-integration-kafka/pull/208)
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,16 @@ java {
 String confluentKafkaVersion = '8.0.0'
 String apacheKafkaVersion = '4.1.0'
 
+configurations.configureEach {
+    resolutionStrategy {
+        capabilitiesResolution {
+            withCapability("org.lz4:lz4-java") {
+                select(candidates.find { ((ModuleComponentIdentifier) it.id).group == "at.yawk.lz4" })
+            }
+        }
+    }
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -71,7 +81,7 @@ dependencies {
     // slf4j, zstd, lz4-java, and snappy are dependencies from "kafka-clients"
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.github.luben:zstd-jni:1.5.6-10'
-    implementation 'org.lz4:lz4-java:1.8.0'
+    implementation 'at.yawk.lz4:lz4-java:1.10.1'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.7'
 }
 task generateGemJarRequiresFile {

--- a/logstash-integration-kafka.gemspec
+++ b/logstash-integration-kafka.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-kafka'
-  s.version         = '12.0.1'
+  s.version         = '12.0.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Kafka - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+
                       "using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
-  s.require_paths   = ['lib', 'vendor/jar-dependencies']
+  s.homepage        = "https://www.elastic.co/logstash"
+  s.require_paths   = %w[lib vendor/jar-dependencies]
 
   # Files
   s.files = Dir.glob(%w(


### PR DESCRIPTION
Replaces https://github.com/logstash-plugins/logstash-integration-kafka/pull/211

This needs to be backported to 11.x as well.