### PR TITLE
Remove End-of-Life Logstash 7.x from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,2 @@
 import:
   - logstash-plugins/.ci:travis/travis.yml@1.x
-
-# lock on version 8.x because use of Jackson 2.13.3 available from 8.3.0
-jobs:
-  exclude:
-  - env: ELASTIC_STACK_VERSION=7.current
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.current


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

Backport of https://github.com/logstash-plugins/logstash-integration-kafka/pull/219