### PR TITLE
Finalize migration from travis to GHA

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Plugin Unit Tests
 
 on:
   push:
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
-    uses: logstash-plugins/.ci/.github/workflows/test.yml@feature/github-actions
+  unit-tests:
+    uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-import:
-  - logstash-plugins/.ci:travis/travis.yml@1.x


### PR DESCRIPTION
Use the renamed shared workflow and remove the travis config

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
