### PR TITLE
Finalize migration from travis to GHA (#256)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,24 @@
+name: Plugin Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+      - '11.x'
+  pull_request:
+    branches:
+      - main
+      - '11.x'
+  schedule:
+    # Run daily at 08:00 UTC on active branches
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}
+    with:
+      timeout-minutes: 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-import:
-  - logstash-plugins/.ci:travis/travis.yml@1.x


### PR DESCRIPTION
Use the renamed shared workflow and remove the travis config

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
