### PR TITLE
Add secrets: inherit to reusable workflow callers

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,7 @@ jobs:
   unit-tests:
     if: github.event_name != 'schedule'
     uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    secrets: inherit
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}
@@ -34,6 +35,7 @@ jobs:
       matrix:
         branch: ['main', '11.x']
     uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    secrets: inherit
     with:
       ref: ${{ matrix.branch }}
       timeout-minutes: 90


### PR DESCRIPTION
## What

Adds `secrets: inherit` to every reusable-workflow caller job in this repo's `.github/workflows/`.

## Why

The reusable workflows in `logstash-plugins/.ci` (`1.x`) now run a failure-notification step that reads `secrets.SLACK_BOT_TOKEN` (logstash-plugins/.ci#134). The reusables do **not** declare a `workflow_call.secrets:` block, so callers must pass `secrets: inherit` on each reusable-call job for the token to reach the notification step.

Without it the token is empty and Slack failure notifications silently never fire (tests otherwise pass). This change is a no-op for test execution; it only enables the failure-notification path.