### PR TITLE
update jackson to 2.21.6 (11.x backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ java {
 // Confluent Platform 7.9.x is Apache Kafka 3.9.x
 String confluentKafkaVersion = '7.9.5'
 String apacheKafkaVersion = '3.9.2'
-String jacksonVersion = '2.21.4'
+String jacksonVersion = '2.21.6'
 
 configurations.configureEach {
     resolutionStrategy {


### PR DESCRIPTION
Backport of #274 to the 11.x line. Get the latest 2.21 LTS jackson patch.

Relates: https://github.com/elastic/logstash/issues/19440